### PR TITLE
fix: unsave when cancel

### DIFF
--- a/src/lib/pages/contracts/components/table/ContractNameCell.tsx
+++ b/src/lib/pages/contracts/components/table/ContractNameCell.tsx
@@ -97,7 +97,6 @@ export const ContractName = ({
             onMouseOver={handleMouseEnterText}
             onMouseOut={handleMouseOutText}
           >
-            {/* TODO change to css */}
             <Text
               variant="body2"
               className="ellipsis"


### PR DESCRIPTION
## Describe your changes
- fix contract name changed when canceling during quick editing name cell

## Demo Link
- https://celatone-frontend-git-fix-unset-on-cancel-alles-labs.vercel.app