### PR TITLE
feat: scroll to top when route change, pagination, and success instantiation

### DIFF
--- a/src/lib/components/pagination/index.tsx
+++ b/src/lib/components/pagination/index.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo } from "react";
 import { MdKeyboardArrowLeft, MdKeyboardArrowRight } from "react-icons/md";
 import { TiArrowSortedDown } from "react-icons/ti";
 
+import { scrollTop } from "lib/utils/scrollTop";
+
 import { Next } from "./Next";
 import { Paginator } from "./Paginator";
 import { Previous } from "./Previous";
@@ -27,7 +29,7 @@ export const Pagination = ({
   onPageSizeChange,
 }: PaginationProps) => {
   useEffect(() => {
-    document.getElementById("content")?.scroll(0, 0);
+    scrollTop();
   }, [currentPage, pageSize]);
 
   const { offsetData, lastDataInPage } = useMemo(() => {

--- a/src/lib/layout/index.tsx
+++ b/src/lib/layout/index.tsx
@@ -3,6 +3,8 @@ import { useRouter } from "next/router";
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 
+import { scrollTop } from "lib/utils/scrollTop";
+
 import Header from "./Header";
 import Navbar from "./Navbar";
 
@@ -14,7 +16,7 @@ const Layout = ({ children }: LayoutProps) => {
   const router = useRouter();
 
   useEffect(() => {
-    document.getElementById("content")?.scroll(0, 0);
+    scrollTop();
   }, [router.asPath]);
 
   return (

--- a/src/lib/pages/instantiate/index.tsx
+++ b/src/lib/pages/instantiate/index.tsx
@@ -1,6 +1,8 @@
 import type { InstantiateResult } from "@cosmjs/cosmwasm-stargate";
 import { useEffect, useState } from "react";
 
+import { scrollTop } from "lib/utils/scrollTop";
+
 import CompletedPage from "./completed";
 import InstantiatePage from "./instantiate";
 
@@ -22,7 +24,7 @@ const Index = () => {
   });
 
   useEffect(() => {
-    document.getElementById("content")?.scroll(0, 0);
+    scrollTop();
   }, [completed]);
 
   return completed && txInfo ? (

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -9,3 +9,4 @@ export * from "./number";
 export * from "./isDecimalNumber";
 export * from "./extractMsgType";
 export * from "./redo";
+export * from "./scrollTop";

--- a/src/lib/utils/scrollTop.ts
+++ b/src/lib/utils/scrollTop.ts
@@ -1,0 +1,3 @@
+export const scrollTop = () => {
+  document.getElementById("content")?.scroll(0, 0);
+};


### PR DESCRIPTION
Apply scroll to the top of the page 
- when route change
- Pagination (when the number of items displayed on page change and when navigating within the pagination)
- When instantiate new contract is completed
