### PR TITLE
fix: temporarily remove osmosis mainnet

### DIFF
--- a/src/lib/data/wallet.ts
+++ b/src/lib/data/wallet.ts
@@ -1,4 +1,4 @@
-export const MAINNET_CHAIN_NAMES = ["osmosis"];
+export const MAINNET_CHAIN_NAMES = [];
 
 export const TESTNET_CHAIN_NAMES = ["osmosistestnet"];
 


### PR DESCRIPTION
## Describe your changes

Temporarily remove Osmosis mainnet from the selectable chain list. This will be re-added once we have the mainnet indexer up.

Currently, only the Osmosis testnet will be supported.
