### PR TITLE
fix(components): change code list search to startswith from contains

### DIFF
--- a/src/lib/pages/codes/data.ts
+++ b/src/lib/pages/codes/data.ts
@@ -62,7 +62,7 @@ export const useCodeListData = (keyword?: string): CodeListData => {
       if (computedKeyword.length === 0) return true;
 
       return (
-        code.id.toString().includes(computedKeyword) ||
+        code.id.toString().startsWith(computedKeyword) ||
         code.description?.toLowerCase().includes(computedKeyword.toLowerCase())
       );
     };


### PR DESCRIPTION
## Describe your changes

Previously, when users searched for code IDs in 'Code Lists' the search filtering logic used `contains` function. This means that, for example, if the user has a code list of [121, 4121, 5321], searching for '1' would return all three codes as valid search results.

However, the expected behavior should only return the first entry in the list.
