### PR TITLE
Disable Sentry debug to prevent "logger.info is not a function" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+- [#229](https://github.com/alleslabs/celatone-frontend/pull/229) Disable Sentry debug to prevent "logger.info is not a function" error
 - [#219](https://github.com/alleslabs/celatone-frontend/pull/219) Fix asset value and price formatter
 - [#217](https://github.com/alleslabs/celatone-frontend/pull/217) Fix state reset in Save New Code modal and no permission in migration
 

--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,15 @@ const nextConfig = {
   eslint: {
     dirs: ["src"],
   },
+  webpack: (config, { webpack }) => {
+    config.plugins.push(
+      new webpack.DefinePlugin({
+        __SENTRY_DEBUG__: false,
+      })
+    );
+
+    return config;
+  },
   async rewrites() {
     return [
       {


### PR DESCRIPTION
## Describe your changes

I noticed that the logger.info function in the [tunnelRoute.ts](https://github.com/getsentry/sentry-javascript/blob/master/packages/nextjs/src/client/tunnelRoute.ts#L20) file is causing an error when Sentry debug is enabled. To prevent this issue from occurring, I have proposed a workaround solution to disabling the logger by setting the `__DEBUG_BUILD__` flag to false via the `__SENTRY_DEBUG__` environment variable.
