### PR TITLE
fix: double slash for endpoint, disable calling endpoint when there is no contract addr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+- [#231](https://github.com/alleslabs/celatone-frontend/pull/231) Fix double slash for endpoint, disable calling endpoint when there is no contract addr in contract details page
 - [#229](https://github.com/alleslabs/celatone-frontend/pull/229) Disable Sentry debug to prevent "logger.info is not a function" error
 - [#219](https://github.com/alleslabs/celatone-frontend/pull/219) Fix asset value and price formatter
 - [#217](https://github.com/alleslabs/celatone-frontend/pull/217) Fix state reset in Save New Code modal and no permission in migration

--- a/src/env.ts
+++ b/src/env.ts
@@ -40,10 +40,10 @@ export const CELATONE_APP_CONTRACT_ADDRESS = (
 };
 
 export const FALLBACK_LCD_ENDPOINT: Record<string, string> = {
-  osmosis: "https://lcd.osmosis.zone",
-  osmosistestnet: "https://lcd-test.osmosis.zone",
-  terra2: "https://phoenix-lcd.terra.dev",
-  terra2testnet: "https://pisco-lcd.terra.dev",
+  osmosis: "https://lcd.osmosis.zone/",
+  osmosistestnet: "https://lcd-test.osmosis.zone/",
+  terra2: "https://phoenix-lcd.terra.dev/",
+  terra2testnet: "https://pisco-lcd.terra.dev/",
 };
 
 export const MAX_FILE_SIZE = 800_000;

--- a/src/lib/model/contract.ts
+++ b/src/lib/model/contract.ts
@@ -107,14 +107,14 @@ export const useContractData = (
       ["query", "instantiate_info", endpoint, contractAddress],
       async () =>
         queryInstantiateInfo(endpoint, indexerGraphClient, contractAddress),
-      { enabled: !!currentChainRecord, retry: false }
+      { enabled: !!currentChainRecord && !!contractAddress, retry: false }
     );
 
   const { data: contractCw2Info, isLoading: isContractCw2InfoLoading } =
     useQuery(
       ["query", "contract_cw2_info", endpoint, contractAddress],
       async () => queryContractCw2Info(endpoint, contractAddress),
-      { enabled: !!currentChainRecord, retry: false }
+      { enabled: !!currentChainRecord && !!contractAddress, retry: false }
     );
 
   const { data: contractBalances, isLoading: isContractBalancesLoading } =
@@ -126,7 +126,7 @@ export const useContractData = (
           currentChainRecord?.chain.chain_id,
           contractAddress
         ),
-      { enabled: !!currentChainRecord, retry: false }
+      { enabled: !!currentChainRecord && !!contractAddress, retry: false }
     );
 
   const contractBalancesWithAssetInfos = contractBalances

--- a/src/lib/services/code.ts
+++ b/src/lib/services/code.ts
@@ -21,7 +21,7 @@ export const getCodeIdInfo = async (
   id: number
 ): Promise<CodeIdInfoResponse> => {
   const { data } = await axios.get<CodeIdInfoResponse>(
-    `${endpoint}/cosmwasm/wasm/v1/code/${id}`
+    `${endpoint}cosmwasm/wasm/v1/code/${id}`
   );
   return data;
 };

--- a/src/lib/services/contract.ts
+++ b/src/lib/services/contract.ts
@@ -63,7 +63,7 @@ export const queryData = async (
 ) => {
   const b64 = encode(msg);
   const { data } = await axios.get(
-    `${endpoint}/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${b64}`
+    `${endpoint}cosmwasm/wasm/v1/contract/${contractAddress}/smart/${b64}`
   );
   return data;
 };
@@ -73,7 +73,7 @@ export const queryContract = async (
   contractAddress: ContractAddr
 ) => {
   const { data } = await axios.get<ContractResponse>(
-    `${endpoint}/cosmwasm/wasm/v1/contract/${contractAddress}`
+    `${endpoint}cosmwasm/wasm/v1/contract/${contractAddress}`
   );
   return data;
 };
@@ -83,7 +83,7 @@ export const queryContractCw2Info = async (
   contractAddress: ContractAddr
 ) => {
   const { data } = await axios.get<ContractCw2InfoRaw>(
-    `${endpoint}/cosmwasm/wasm/v1/contract/${contractAddress}/raw/Y29udHJhY3RfaW5mbw%3D%3D`
+    `${endpoint}cosmwasm/wasm/v1/contract/${contractAddress}/raw/Y29udHJhY3RfaW5mbw%3D%3D`
   );
   return JSON.parse(libDecode(data.data)) as ContractCw2Info;
 };


### PR DESCRIPTION
- Fix double slash for endpoint `https://lcd-test.osmosis.zone//cosmwasm/wasm/v1/contract/`
- Disable calling endpoint when there is no contract address in contract detail page `https://lcd-test.osmosis.zone//cosmwasm/wasm/v1/contract/`

Note: endpoint from useWallet contains / at the end, so add / to fallback url