### PR TITLE
fix: show edit button when code name is set and align all buttons to top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
+- [#246](https://github.com/alleslabs/celatone-frontend/pull/246) Show edit button when code name is set, and align button section to top
 - [#239](https://github.com/alleslabs/celatone-frontend/pull/239) Add code description and code name for public code in code details page
 - [#237](https://github.com/alleslabs/celatone-frontend/pull/237) Change unsupported tokens layout and style
 

--- a/src/lib/pages/code-details/components/CTASection.tsx
+++ b/src/lib/pages/code-details/components/CTASection.tsx
@@ -8,12 +8,14 @@ import { useCodeStore } from "lib/providers/store";
 import type { CodeInfo } from "lib/types";
 
 export const CTASection = observer((codeInfo: CodeInfo) => {
-  const { isCodeIdSaved } = useCodeStore();
+  const { isCodeIdSaved, getCodeLocalInfo } = useCodeStore();
   const isSaved = isCodeIdSaved(codeInfo.id);
 
   return (
     <Flex gap={4}>
-      {isSaved && <SaveOrEditCodeModal mode="edit" codeInfo={codeInfo} />}
+      {(getCodeLocalInfo(codeInfo.id)?.name || isSaved) && (
+        <SaveOrEditCodeModal mode="edit" codeInfo={codeInfo} />
+      )}
       <InstantiateButton
         instantiatePermission={codeInfo.instantiatePermission}
         permissionAddresses={codeInfo.permissionAddresses}

--- a/src/lib/pages/code-details/index.tsx
+++ b/src/lib/pages/code-details/index.tsx
@@ -40,7 +40,7 @@ const CodeDetailsBody = observer(
 
     return (
       <>
-        <Flex align="center" justify="space-between" mt={6}>
+        <Flex justify="space-between" mt={6}>
           <Flex direction="column" gap={1}>
             <Flex gap={1}>
               {publicProject.publicDetail?.logo && (


### PR DESCRIPTION
## Describe your changes
- Show edit button when code name is set.
- Align button section to top
