### PR TITLE
fix: remove keepPreviousData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+- [#253](https://github.com/alleslabs/celatone-frontend/pull/253) Fix public code logo shown when switching from mainnet to testnet
 - [#248](https://github.com/alleslabs/celatone-frontend/pull/248) Fix table padding bottom for editable cells
 - [#241](https://github.com/alleslabs/celatone-frontend/pull/241) Fix NAToken size
 - [#244](https://github.com/alleslabs/celatone-frontend/pull/244) Fix json funds instantiate cannot edit

--- a/src/lib/services/publicProjectService.ts
+++ b/src/lib/services/publicProjectService.ts
@@ -67,27 +67,23 @@ export const usePublicProjectBySlug = (
     if (!slug) throw new Error("No project selected (usePublicProjectBySlug)");
     if (!currentChainRecord)
       throw new Error("No chain selected (usePublicProjectBySlug)");
-    return (
-      axios
-        .get<RawPublicProjectInfo>(
-          `${CELATONE_API_ENDPOINT}/projects/${getChainApiPath(
-            currentChainRecord.chain.chain_name
-          )}/${getMainnetApiPath(currentChainRecord.chain.chain_id)}/${slug}`
-        )
-        // eslint-disable-next-line sonarjs/no-identical-functions
-        .then<PublicProjectInfo>(({ data: project }) => ({
-          ...project,
-          codes: project.codes.map(parseCode),
-          contracts: project.contracts.map(parseContract),
-        }))
-    );
+    return axios
+      .get<RawPublicProjectInfo>(
+        `${CELATONE_API_ENDPOINT}/projects/${getChainApiPath(
+          currentChainRecord.chain.chain_name
+        )}/${getMainnetApiPath(currentChainRecord.chain.chain_id)}/${slug}`
+      )
+      .then<PublicProjectInfo>(({ data: publicProject }) => ({
+        ...publicProject,
+        codes: publicProject.codes.map(parseCode),
+        contracts: publicProject.contracts.map(parseContract),
+      }));
   }, [currentChainRecord, slug]);
 
   return useQuery(
     ["public_project_by_slug", slug, currentChainRecord],
     queryFn,
     {
-      keepPreviousData: true,
       enabled: !!slug,
     }
   );


### PR DESCRIPTION
## Describe your changes
When switching from mainnet to testnet in code details page, public project logo should disappear
- Solve by removing `keepPreviousData` 
