### PR TITLE
fix: token card, font size, text color in blocks and account details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+- [#302](https://github.com/alleslabs/celatone-frontend/pull/302) Fix token card width, text size for unsupported token button in account details page and tx count color when equal to zero
 - [#290](https://github.com/alleslabs/celatone-frontend/pull/290) Fix spacing and styling in account detail
 - [#280](https://github.com/alleslabs/celatone-frontend/pull/280) Fix begin unlocking optional coins field causing crash
 - [#269](https://github.com/alleslabs/celatone-frontend/pull/269) Fix array value json string format and receipt row text color

--- a/src/lib/components/modal/UnsupportedTokensModal.tsx
+++ b/src/lib/components/modal/UnsupportedTokensModal.tsx
@@ -172,6 +172,7 @@ export const UnsupportedTokensModal = ({
           variant="ghost"
           color="text.dark"
           mb={1}
+          fontSize="12px"
           fontWeight={500}
           {...buttonProps}
         >

--- a/src/lib/pages/account-details/components/asset/index.tsx
+++ b/src/lib/pages/account-details/components/asset/index.tsx
@@ -42,7 +42,7 @@ const AssetSectionContent = ({
       {supportedAssets
         .slice(0, onViewMore ? MaxAssetsShow : undefined)
         .map((asset) => (
-          <TokenCard userBalance={asset} key={asset.balance.id} />
+          <TokenCard userBalance={asset} key={asset.balance.id} minW="full" />
         ))}
     </Grid>
   ) : (

--- a/src/lib/pages/blocks/components/BlocksRow.tsx
+++ b/src/lib/pages/blocks/components/BlocksRow.tsx
@@ -28,7 +28,12 @@ export const BlocksRow = ({ templateColumns, blockData }: BlocksRowProps) => {
       <TableRow>
         <ValidatorBadge validator={blockData.proposer} />
       </TableRow>
-      <TableRow justifyContent="center">{blockData.txCount}</TableRow>
+      <TableRow
+        justifyContent="center"
+        color={blockData.txCount === 0 ? "text.dark" : "text.main"}
+      >
+        {blockData.txCount}
+      </TableRow>
       <TableRow>
         <Flex direction="column">
           <Text variant="body2" color="text.dark" mb="2px">


### PR DESCRIPTION
Account details page
- card token size
- font size for unsupported token button

Blocks page
- when tx count equal to zero, should render a secondary text color
