### PR TITLE
feat: add amplitude to proposal to store code page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
+- [#321](https://github.com/alleslabs/celatone-frontend/pull/321) Add amplitude to proposal to store code page
 - [#274](https://github.com/alleslabs/celatone-frontend/pull/274) Add proposal to store code page
 - [#279](https://github.com/alleslabs/celatone-frontend/pull/279) Add instantiate permission to msg store code, change error display design, and upgrade cosmjs to version 0.30.1
 

--- a/src/lib/components/ConnectWalletAlert.tsx
+++ b/src/lib/components/ConnectWalletAlert.tsx
@@ -11,24 +11,26 @@ import type { AlertProps } from "@chakra-ui/react";
 import { useWallet } from "@cosmos-kit/react";
 import type { MouseEventHandler } from "react";
 
-import { AmpEvent, AmpTrack } from "lib/services/amplitude";
+import { AmpTrackUseClickWallet } from "lib/services/amplitude";
 
 import { CustomIcon } from "./icon";
 
 interface ConnectWalletAlertProps extends AlertProps {
   title?: string;
   subtitle?: string;
+  page?: string;
 }
 
 export const ConnectWalletAlert = ({
   title,
   subtitle,
+  page,
   ...alertProps
 }: ConnectWalletAlertProps) => {
   const { address, connect } = useWallet();
 
   const onClickConnect: MouseEventHandler = async (e) => {
-    AmpTrack(AmpEvent.USE_CLICK_WALLET);
+    AmpTrackUseClickWallet(page, "alert");
     e.preventDefault();
     await connect();
   };

--- a/src/lib/components/StickySidebar.tsx
+++ b/src/lib/components/StickySidebar.tsx
@@ -17,10 +17,12 @@ import {
 } from "lib/app-provider";
 import type { Network } from "lib/data";
 import { getChainNameByNetwork } from "lib/data";
+import { AmpTrackUseRightHelperPanel } from "lib/services/amplitude";
 
 import { CustomIcon } from "./icon";
 
 export interface SidebarMetadata {
+  page: string;
   title: string;
   description: React.ReactElement;
   toNetwork?: boolean;
@@ -70,8 +72,15 @@ export const StickySidebar = ({
   const selectChain = useSelectChain();
   const { isMainnet } = useCurrentNetwork();
   const { network } = useCurrentNetwork();
-  const { title, description, toNetwork, toPagePath, toPageTitle, toPage } =
-    metadata[network];
+  const {
+    title,
+    description,
+    toNetwork,
+    toPagePath,
+    toPageTitle,
+    toPage,
+    page,
+  } = metadata[network];
   const hasAction = toPage;
   return (
     <Box flex="4" px={8} position="relative" {...boxProps}>
@@ -105,17 +114,21 @@ export const StickySidebar = ({
               </Text>
               {toNetwork && (
                 <ToPage
-                  onClick={() =>
+                  onClick={() => {
+                    AmpTrackUseRightHelperPanel(page, "change-network");
                     selectChain(
                       getChainNameByNetwork(isMainnet ? "testnet" : "mainnet")
-                    )
-                  }
+                    );
+                  }}
                   title={isMainnet ? "Switch To Testnet" : "Switch To Mainnet"}
                 />
               )}
               {toPage && toPagePath && toPageTitle && (
                 <ToPage
-                  onClick={() => navigate({ pathname: toPagePath })}
+                  onClick={() => {
+                    AmpTrackUseRightHelperPanel(page, `to-${toPagePath}`);
+                    navigate({ pathname: toPagePath });
+                  }}
                   title={toPageTitle}
                 />
               )}

--- a/src/lib/components/upload/InstantiatePermissionRadio.tsx
+++ b/src/lib/components/upload/InstantiatePermissionRadio.tsx
@@ -70,7 +70,7 @@ export const InstantiatePermissionRadio = ({
         emptyAddressesLength,
         addresses.length - emptyAddressesLength
       );
-  }, [addresses, append, page, permission, remove]);
+  }, [addresses, page, permission]);
 
   return (
     <RadioGroup

--- a/src/lib/components/upload/InstantiatePermissionRadio.tsx
+++ b/src/lib/components/upload/InstantiatePermissionRadio.tsx
@@ -1,12 +1,17 @@
 import { Text, Box, Radio, RadioGroup, Button, Flex } from "@chakra-ui/react";
 import { useWallet } from "@cosmos-kit/react";
+import { useEffect } from "react";
 import type { Control, UseFormSetValue, UseFormTrigger } from "react-hook-form";
 import { useController, useFieldArray, useWatch } from "react-hook-form";
 
 import { AddressInput } from "../AddressInput";
 import { AssignMe } from "../AssignMe";
 import { CustomIcon } from "lib/components/icon";
-import { AmpEvent, AmpTrack } from "lib/services/amplitude";
+import {
+  AmpEvent,
+  AmpTrack,
+  AmpTrackUseInstantiatePermission,
+} from "lib/services/amplitude";
 import type { Addr, UploadSectionState } from "lib/types";
 import { AccessType } from "lib/types";
 
@@ -14,6 +19,7 @@ interface InstantiatePermissionRadioProps {
   control: Control<UploadSectionState>;
   setValue: UseFormSetValue<UploadSectionState>;
   trigger: UseFormTrigger<UploadSectionState>;
+  page?: string;
 }
 
 interface PermissionRadioProps {
@@ -32,6 +38,7 @@ export const InstantiatePermissionRadio = ({
   control,
   setValue,
   trigger,
+  page,
 }: InstantiatePermissionRadioProps) => {
   const { address: walletAddress } = useWallet();
 
@@ -51,6 +58,19 @@ export const InstantiatePermissionRadio = ({
     control,
     name: "addresses",
   });
+
+  useEffect(() => {
+    const emptyAddressesLength = addresses.filter(
+      (addr) => addr.address.trim().length === 0
+    ).length;
+    if (page)
+      AmpTrackUseInstantiatePermission(
+        page,
+        permission,
+        emptyAddressesLength,
+        addresses.length - emptyAddressesLength
+      );
+  }, [addresses, append, page, permission, remove]);
 
   return (
     <RadioGroup

--- a/src/lib/pages/proposal/constants.tsx
+++ b/src/lib/pages/proposal/constants.tsx
@@ -1,3 +1,4 @@
+import { Text } from "@chakra-ui/react";
 import Link from "next/link";
 
 import type { SidebarDetails } from "lib/components/StickySidebar";
@@ -84,7 +85,9 @@ export const SIDEBAR_STORE_CODE_DETAILS: SidebarDetails = {
           }
         >
           {" "}
-          <span style={{ color: "#D8BEFC" }}>Deploy Contract</span>
+          <Text as="span" color="lilac.main">
+            Deploy Contract
+          </Text>
         </Link>
         <br />
         <br />

--- a/src/lib/pages/proposal/constants.tsx
+++ b/src/lib/pages/proposal/constants.tsx
@@ -1,9 +1,12 @@
 import Link from "next/link";
 
 import type { SidebarDetails } from "lib/components/StickySidebar";
+import { AmpTrackUseRightHelperPanel } from "lib/services/amplitude";
 
+const whitelistPage = "proposal-whitelist";
 export const SIDEBAR_WHITELIST_DETAILS: SidebarDetails = {
   mainnet: {
+    page: whitelistPage,
     title: "What is whitelisted address?",
     description: (
       <span>
@@ -24,6 +27,7 @@ export const SIDEBAR_WHITELIST_DETAILS: SidebarDetails = {
     toPageTitle: "Submit Proposal To Store Code",
   },
   testnet: {
+    page: whitelistPage,
     title: "Do I need to open proposal to whitelisting in testnet?",
     description: (
       <span>
@@ -40,13 +44,16 @@ export const SIDEBAR_WHITELIST_DETAILS: SidebarDetails = {
   },
   // TODO: fill localnet information
   localnet: {
+    page: whitelistPage,
     title: "",
     description: <span />,
   },
 };
 
+const storeCodePage = "proposal-store-code";
 export const SIDEBAR_STORE_CODE_DETAILS: SidebarDetails = {
   mainnet: {
+    page: storeCodePage,
     title: "Why do I need to submit proposal?",
     description: (
       <span>
@@ -64,12 +71,18 @@ export const SIDEBAR_STORE_CODE_DETAILS: SidebarDetails = {
     toNetwork: true,
   },
   testnet: {
+    page: storeCodePage,
     title: "Do I need to submit Proposal to store code in testnet?",
     description: (
       <span>
         On the Osmosis testnet, you can store code without submitting a proposal
         by using
-        <Link href="/deploy">
+        <Link
+          href="/deploy"
+          onClick={() =>
+            AmpTrackUseRightHelperPanel(storeCodePage, "to-/deploy")
+          }
+        >
           {" "}
           <span style={{ color: "#D8BEFC" }}>Deploy Contract</span>
         </Link>
@@ -89,6 +102,7 @@ export const SIDEBAR_STORE_CODE_DETAILS: SidebarDetails = {
   },
   // TODO: fill localnet information
   localnet: {
+    page: storeCodePage,
     title: "",
     description: <span />,
   },

--- a/src/lib/pages/proposal/store-code/index.tsx
+++ b/src/lib/pages/proposal/store-code/index.tsx
@@ -86,6 +86,8 @@ const defaultValues: StoreCodeProposalState = {
   codeHash: "",
 };
 
+const page = "proposal-store-code";
+
 const StoreCodeProposal = () => {
   const {
     appHumanAddress: { example: exampleHumanAddress },
@@ -97,7 +99,6 @@ const StoreCodeProposal = () => {
   const { validateUserAddress, validateContractAddress } = useValidateAddress();
   const submitStoreCodeProposalTx = useSubmitStoreCodeProposalTx();
   const { broadcast } = useTxBroadcast();
-  const page = "proposal-store-code";
 
   // States
   const [estimatedFee, setEstimatedFee] = useState<StdFee>();
@@ -265,15 +266,12 @@ const StoreCodeProposal = () => {
   const proceed = useCallback(async () => {
     if (!wasmFile) return null;
 
-    AmpTrackUseSubmitProposal(
-      page,
-      initialDeposit.amount,
-      minDeposit?.formattedAmount,
-      {
-        addressesCount: addresses.length,
-        permission: AccessType[permission],
-      }
-    );
+    AmpTrackUseSubmitProposal(page, {
+      initialDeposit: initialDeposit.amount,
+      minDeposit: minDeposit?.formattedAmount,
+      addressesCount: addresses.length,
+      permission: AccessType[permission],
+    });
 
     const submitStoreCodeProposalMsg = async () => {
       return composeStoreCodeProposalMsg({

--- a/src/lib/pages/proposal/store-code/index.tsx
+++ b/src/lib/pages/proposal/store-code/index.tsx
@@ -51,6 +51,7 @@ import {
   AmpEvent,
   AmpTrack,
   AmpTrackUseDepositFill,
+  AmpTrackUseSubmitProposal,
   AmpTrackUseUnpin,
 } from "lib/services/amplitude";
 import { useGovParams } from "lib/services/proposalService";
@@ -96,6 +97,7 @@ const StoreCodeProposal = () => {
   const { validateUserAddress, validateContractAddress } = useValidateAddress();
   const submitStoreCodeProposalTx = useSubmitStoreCodeProposalTx();
   const { broadcast } = useTxBroadcast();
+  const page = "proposal-store-code";
 
   // States
   const [estimatedFee, setEstimatedFee] = useState<StdFee>();
@@ -263,10 +265,15 @@ const StoreCodeProposal = () => {
   const proceed = useCallback(async () => {
     if (!wasmFile) return null;
 
-    AmpTrack(AmpEvent.USE_SUBMIT_PROPOSAL, {
-      addressesCount: addresses.length,
-      permission: AccessType[permission],
-    });
+    AmpTrackUseSubmitProposal(
+      page,
+      initialDeposit.amount,
+      minDeposit?.formattedAmount,
+      {
+        addressesCount: addresses.length,
+        permission: AccessType[permission],
+      }
+    );
 
     const submitStoreCodeProposalMsg = async () => {
       return composeStoreCodeProposalMsg({
@@ -320,8 +327,6 @@ const StoreCodeProposal = () => {
     walletAddress,
     wasmFile,
   ]);
-
-  const page = "proposal-store-code";
 
   return (
     <>

--- a/src/lib/services/amplitude.tsx
+++ b/src/lib/services/amplitude.tsx
@@ -2,8 +2,7 @@ import { track } from "@amplitude/analytics-browser";
 import big from "big.js";
 
 import type { AttachFundsType } from "lib/components/fund/types";
-import type { Dict, Option, Token } from "lib/types";
-import { AccessType } from "lib/types";
+import type { Option, Token, AccessType } from "lib/types";
 
 export enum AmpEvent {
   INVALID_STATE = "To Invalid State",
@@ -229,7 +228,7 @@ export const AmpTrackUseInstantiatePermission = (
 ) =>
   track(AmpEvent.USE_INSTANTIATE_PERMISSION, {
     page,
-    type: AccessType[type],
+    type,
     emptyAddressesLength,
     addressesLength,
   });
@@ -239,12 +238,17 @@ export const AmpTrackUseDepositFill = (page: string, amount: Token) =>
 
 export const AmpTrackUseSubmitProposal = (
   page: string,
-  initialDeposit: string,
-  minDeposit: Option<string>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  properties?: Dict<string, any>
+  properties: {
+    initialDeposit: string;
+    minDeposit: Option<string>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
+  }
 ) => {
-  const proposalPeriod =
-    big(initialDeposit) < big(minDeposit || "0") ? "Deposit" : "Voting";
+  const proposalPeriod = big(properties.initialDeposit).lt(
+    properties.minDeposit || "0"
+  )
+    ? "Deposit"
+    : "Voting";
   track(AmpEvent.USE_SUBMIT_PROPOSAL, { page, proposalPeriod, ...properties });
 };

--- a/src/lib/services/amplitude.tsx
+++ b/src/lib/services/amplitude.tsx
@@ -1,7 +1,8 @@
 import { track } from "@amplitude/analytics-browser";
 
 import type { AttachFundsType } from "lib/components/fund/types";
-import type { Option } from "lib/types";
+import type { Option, Token } from "lib/types";
+import { AccessType } from "lib/types";
 
 export enum AmpEvent {
   INVALID_STATE = "To Invalid State",
@@ -54,6 +55,7 @@ export enum AmpEvent {
   TO_TRANSACTION_DETAIL = "To Transaction Detail",
   TO_NOT_FOUND = "To 404 Not Found",
   TO_FAUCET = "To Faucet",
+  TO_PROPOSAL_TO_STORE_CODE = "To Proposal To Store Code",
   // ACTIONS
   ACTION_UPLOAD = "Act Upload",
   ACTION_INSTANTIATE = "Action Instantiate",
@@ -96,6 +98,11 @@ export enum AmpEvent {
   USE_UNSUPPORTED_ASSETS = "Use Unsupported Assets",
   USE_TX_MSG_EXPAND = "Use Transaction Message Expand",
   USE_EXPAND = "Use General Expand",
+  USE_RIGHT_HELPER_PANEL = "Use Right Helper Panel", // Sticky panel
+  USE_UNPIN = "Use Unpin",
+  USE_INSTANTIATE_PERMISSION = "Use Instantiate Permission",
+  USE_DEPOSIT_FILL = "Use Deposit Fill",
+  USE_SUBMIT_PROPOSAL = "Use Submit Proposal",
   // TX
   TX_SUCCEED = "Tx Succeed",
   TX_FAILED = "Tx Failed",
@@ -131,7 +138,11 @@ type SpecialAmpEvent =
   | AmpEvent.USE_VIEW_JSON
   | AmpEvent.USE_UNSUPPORTED_ASSETS
   | AmpEvent.USE_COPIER
-  | AmpEvent.USE_EXPAND;
+  | AmpEvent.USE_EXPAND
+  | AmpEvent.USE_RIGHT_HELPER_PANEL
+  | AmpEvent.USE_UNPIN
+  | AmpEvent.USE_INSTANTIATE_PERMISSION
+  | AmpEvent.USE_DEPOSIT_FILL;
 
 export const AmpTrackInvalidState = (title: string) =>
   track(AmpEvent.INVALID_STATE, { title });
@@ -199,3 +210,28 @@ export const AmpTrackExpand = (
   component: "assets" | "json" | "permission_address" | "event_box",
   section: Option<string>
 ) => track(AmpEvent.USE_EXPAND, { action, component, section });
+
+export const AmpTrackUseClickWallet = (page?: string, component?: string) =>
+  track(AmpEvent.USE_CLICK_WALLET, { page, component });
+
+export const AmpTrackUseRightHelperPanel = (page: string, action: string) =>
+  track(AmpEvent.USE_RIGHT_HELPER_PANEL, { page, action });
+
+export const AmpTrackUseUnpin = (page: string, check: boolean) =>
+  track(AmpEvent.USE_UNPIN, { page, check });
+
+export const AmpTrackUseInstantiatePermission = (
+  page: string,
+  type: AccessType,
+  emptyAddressesLength: number,
+  addressesLength: number
+) =>
+  track(AmpEvent.USE_INSTANTIATE_PERMISSION, {
+    page,
+    type: AccessType[type],
+    emptyAddressesLength,
+    addressesLength,
+  });
+
+export const AmpTrackUseDepositFill = (page: string, amount: Token) =>
+  track(AmpEvent.USE_DEPOSIT_FILL, { page, amount });

--- a/src/lib/services/amplitude.tsx
+++ b/src/lib/services/amplitude.tsx
@@ -1,7 +1,8 @@
 import { track } from "@amplitude/analytics-browser";
+import big from "big.js";
 
 import type { AttachFundsType } from "lib/components/fund/types";
-import type { Option, Token } from "lib/types";
+import type { Dict, Option, Token } from "lib/types";
 import { AccessType } from "lib/types";
 
 export enum AmpEvent {
@@ -235,3 +236,15 @@ export const AmpTrackUseInstantiatePermission = (
 
 export const AmpTrackUseDepositFill = (page: string, amount: Token) =>
   track(AmpEvent.USE_DEPOSIT_FILL, { page, amount });
+
+export const AmpTrackUseSubmitProposal = (
+  page: string,
+  initialDeposit: string,
+  minDeposit: Option<string>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  properties?: Dict<string, any>
+) => {
+  const proposalPeriod =
+    big(initialDeposit) < big(minDeposit || "0") ? "Deposit" : "Voting";
+  track(AmpEvent.USE_SUBMIT_PROPOSAL, { page, proposalPeriod, ...properties });
+};


### PR DESCRIPTION
## Describe your changes
Add amplitude to proposal to store code page

- To proposal to store code page
`TO_PROPOSAL_TO_STORE_CODE`
- Connect wallet with alert box
Connect wallet : Alert box → Click on connect wallet + alert box
`USE_CLICK_WALLET, alert`
- CTA Tool tip : Proposal to Store code: Change net 
`USE_RIGHT_HELPER_PANEL, "proposal-store-code", "change-network"`
- CTA Tool tip : Proposal to Store code : to Deploy contract
`USE_RIGHT_HELPER_PANEL, "proposal-store-code", "to-/deploy"`
- Pin/Unpin
`USE_UNPIN, "proposal-store-code", true`
- Instantiate permission
`USE_INSTANTIATE_PERMISSION, "proposal-store-code", permissionType, emptyAddressesLength, nonEmptyAddressesLength`
- Deposit: Fill # on click
`USE_DEPOSIT_FILL, "proposal-store-code", 500`
- Submit Proposal
`USE_SUBMIT_PROPOSAL, addressesCount, permissionType`
- TX
Reject by user
Tx succeed
Tx Fail