### PR TITLE
fix wording

### DIFF
--- a/src/lib/app-fns/tx/upload.tsx
+++ b/src/lib/app-fns/tx/upload.tsx
@@ -92,7 +92,7 @@ export const uploadContractTx = ({
               <span style={{ fontWeight: 700 }}>
                 ‘{codeName || `${wasmFileName}(${codeId})`}’
               </span>{" "}
-              is has been uploaded. Would you like to{" "}
+              has been uploaded. Would you like to{" "}
               {isMigrate ? "migrate" : "instantiate"} your code now?
             </>
           ),


### PR DESCRIPTION
## Describe your changes
After uploading a code, text shows 
`... it has been uploaded...` should be `has been uploaded...`

<img width="621" alt="Screenshot 2023-08-09 at 9 38 40 PM" src="https://github.com/alleslabs/celatone-frontend/assets/58892938/8987afe8-82ed-4d4d-a179-2b5450bcf61d">

## Demo Link
