### PR TITLE
fix: query msg regex for Sylvia contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+- [#690](https://github.com/alleslabs/celatone-frontend/pull/690) Fix query msg regex for Sylvia contract
 - [#689](https://github.com/alleslabs/celatone-frontend/pull/689) Fix execute msg regex for Sylvia contract
 - [#685](https://github.com/alleslabs/celatone-frontend/pull/685) Disable save account in mobile
 - [#683](https://github.com/alleslabs/celatone-frontend/pull/683) Fix save account hex duplicate and search with hex

--- a/src/lib/hooks/useQueryCmds.ts
+++ b/src/lib/hooks/useQueryCmds.ts
@@ -36,7 +36,7 @@ export const useQueryCmds = (contractAddress: ContractAddr) => {
 
         // Check if Sylvia framework
         const sylviaRegex =
-          /Messages supported by this contract: (.*?): query wasm contract failed: invalid request/;
+          /Messages supported by this contract: (.*?)(: query wasm contract failed: invalid request)?$/;
         const contentMatch = resMsg?.match(sylviaRegex);
 
         if (contentMatch && contentMatch[1]) {


### PR DESCRIPTION
## Describe your changes
- Fix query msg regex for Sylvia contract

Previous version's response
```
Sylvia: Error parsing into type transmuter::contract::ContractQueryMsg: Unsupported message received: {\"\":{}}. Messages supported by this contract: calc_in_amt_given_out, calc_out_amt_given_in, get_admin, get_admin_candidate, get_share_denom, get_shares, get_swap_fee, get_total_pool_liquidity, get_total_shares, is_active, spot_price: query wasm contract failed: invalid request
```
New version's response
```
Sylvia: Error parsing into type transmuter::contract::ContractQueryMsg: Unsupported message received: {\"\":{}}. Messages supported by this contract: calc_in_amt_given_out, calc_out_amt_given_in, get_admin, get_admin_candidate, get_share_denom, get_shares, get_swap_fee, get_total_pool_liquidity, get_total_shares, is_active, spot_price
```
