### PR TITLE
fix: typo function name

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,0 @@
-## Describe your changes
-
-## Demo Link

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+- [#1091](https://github.com/alleslabs/celatone-frontend/pull/1091) Fix typo function name
 - [#1075](https://github.com/alleslabs/celatone-frontend/pull/1075) Fix custom minitia minor change
 
 ## v1.7.3

--- a/src/lib/stores/verify-module.test.ts
+++ b/src/lib/stores/verify-module.test.ts
@@ -27,12 +27,12 @@ describe("verifyModule", () => {
     chainId: "chainId",
   };
   test("correctly get verify modules", () => {
-    expect(verifyModuleTaskStore.getVerifyModuleTaskTasks()).toEqual([]);
+    expect(verifyModuleTaskStore.getVerifyModuleTasks()).toEqual([]);
   });
 
   test("correctly get verify modules after adding", () => {
     verifyModuleTaskStore.addVerifyModuleTask(verifyModule);
-    expect(verifyModuleTaskStore.getVerifyModuleTaskTasks()).toEqual([
+    expect(verifyModuleTaskStore.getVerifyModuleTasks()).toEqual([
       verifyModule,
     ]);
   });
@@ -49,7 +49,7 @@ describe("verifyModule", () => {
     };
     verifyModuleTaskStore.addVerifyModuleTask(verifyModule1);
     verifyModuleTaskStore.addVerifyModuleTask(verifyModule2);
-    expect(verifyModuleTaskStore.getVerifyModuleTaskTasks()).toEqual([
+    expect(verifyModuleTaskStore.getVerifyModuleTasks()).toEqual([
       verifyModule2,
       verifyModule1,
       verifyModule,

--- a/src/lib/stores/verify-module.ts
+++ b/src/lib/stores/verify-module.ts
@@ -41,18 +41,17 @@ export class VerifyModuleTaskStore {
 
   isVerifyModuleTaskExist(taskId: string): boolean {
     return (
-      this.getVerifyModuleTaskTasks().findIndex(
-        (item) => item.taskId === taskId
-      ) > -1
+      this.getVerifyModuleTasks().findIndex((item) => item.taskId === taskId) >
+      -1
     );
   }
 
-  getVerifyModuleTaskTasks(): VerifyModuleLocalInfo[] {
+  getVerifyModuleTasks(): VerifyModuleLocalInfo[] {
     return this.modules[this.userKey]?.reverse() ?? [];
   }
 
   getVerifyModuleTask(taskId: string): VerifyModuleLocalInfo | undefined {
-    return this.getVerifyModuleTaskTasks().find(
+    return this.getVerifyModuleTasks().find(
       (module) => module.taskId === taskId
     );
   }
@@ -60,7 +59,7 @@ export class VerifyModuleTaskStore {
   addVerifyModuleTask(verifyModule: VerifyModuleLocalInfo): void {
     if (!this.isVerifyModuleTaskExist(verifyModule.taskId)) {
       this.modules[this.userKey] = [
-        ...this.getVerifyModuleTaskTasks(),
+        ...this.getVerifyModuleTasks(),
         verifyModule,
       ];
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated the CHANGELOG.md to include a new entry for a bug fix related to a typo in a function name, enhancing clarity in documentation.

- **Refactor**
	- Renamed method `getVerifyModuleTaskTasks()` to `getVerifyModuleTasks()` in the `VerifyModuleTaskStore` for improved clarity and consistency across the codebase, ensuring better alignment with naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->