### PR TITLE
fix: bug bash move verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+- [#1119](https://github.com/alleslabs/celatone-frontend/pull/1119) Fix move verification bug bash
 - [#1115](https://github.com/alleslabs/celatone-frontend/pull/1115) Fix move reverify button
 - [#1108](https://github.com/alleslabs/celatone-frontend/pull/1108) Fix example dev config to initialocal
 - [#1107](https://github.com/alleslabs/celatone-frontend/pull/1107) Fix network states config

--- a/src/lib/components/MoveVerifyBadge.tsx
+++ b/src/lib/components/MoveVerifyBadge.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from "react";
-
 import { Tooltip } from "lib/components/Tooltip";
 import { MoveVerifyStatus } from "lib/types";
 
@@ -31,23 +29,21 @@ const MoveVerifyBadgeIcon = ({
   return undefined;
 };
 
+const getMoveVerifyBadgeLabel = (status: MoveVerifyStatus) => {
+  if (status === MoveVerifyStatus.Outdated) {
+    return "This module was republished after verification.";
+  }
+  if (status === MoveVerifyStatus.Verified) {
+    return "This module has been verified.";
+  }
+  return undefined;
+};
+
 export const MoveVerifyBadge = ({
   status,
   hasTooltip = false,
-}: MoveVerifyBadgeProps) => {
-  const label = useMemo(() => {
-    if (status === MoveVerifyStatus.Outdated) {
-      return "This module was republished after verification.";
-    }
-    if (status === MoveVerifyStatus.Verified) {
-      return "This module has been verified.";
-    }
-    return undefined;
-  }, [status]);
-
-  return (
-    <Tooltip hidden={!hasTooltip} label={label}>
-      <MoveVerifyBadgeIcon status={status} />
-    </Tooltip>
-  );
-};
+}: MoveVerifyBadgeProps) => (
+  <Tooltip hidden={!hasTooltip} label={getMoveVerifyBadgeLabel(status)}>
+    <MoveVerifyBadgeIcon status={status} />
+  </Tooltip>
+);

--- a/src/lib/components/MoveVerifyBadge.tsx
+++ b/src/lib/components/MoveVerifyBadge.tsx
@@ -1,12 +1,18 @@
+import { useMemo } from "react";
+
+import { Tooltip } from "lib/components/Tooltip";
 import { MoveVerifyStatus } from "lib/types";
 
 import { CustomIcon } from "./icon";
 
 interface MoveVerifyBadgeProps {
   status: MoveVerifyStatus;
+  hasTooltip?: boolean;
 }
 
-export const MoveVerifyBadge = ({ status }: MoveVerifyBadgeProps) => {
+const MoveVerifyBadgeIcon = ({
+  status,
+}: Pick<MoveVerifyBadgeProps, "status">) => {
   if (status === MoveVerifyStatus.Outdated) {
     return (
       <CustomIcon
@@ -23,4 +29,25 @@ export const MoveVerifyBadge = ({ status }: MoveVerifyBadgeProps) => {
     );
   }
   return undefined;
+};
+
+export const MoveVerifyBadge = ({
+  status,
+  hasTooltip = false,
+}: MoveVerifyBadgeProps) => {
+  const label = useMemo(() => {
+    if (status === MoveVerifyStatus.Outdated) {
+      return "This module was republished after verification.";
+    }
+    if (status === MoveVerifyStatus.Verified) {
+      return "This module has been verified.";
+    }
+    return undefined;
+  }, [status]);
+
+  return (
+    <Tooltip hidden={!hasTooltip} label={label}>
+      <MoveVerifyBadgeIcon status={status} />
+    </Tooltip>
+  );
 };

--- a/src/lib/components/table/modules/ModulePathLink.tsx
+++ b/src/lib/components/table/modules/ModulePathLink.tsx
@@ -44,7 +44,9 @@ export const ModulePathLink = ({
           {`${truncate(hexAddr)} :: ${moduleName}`}
         </Text>
       </AppLink>
-      {moveVerifyStatus && <MoveVerifyBadge status={moveVerifyStatus} />}
+      {moveVerifyStatus && (
+        <MoveVerifyBadge status={moveVerifyStatus} hasTooltip />
+      )}
       <Copier
         type="module_path"
         value={mergeModulePath(hexAddr, moduleName)}

--- a/src/lib/pages/module-details/components/ModuleTop.tsx
+++ b/src/lib/pages/module-details/components/ModuleTop.tsx
@@ -214,9 +214,7 @@ export const ModuleTop = ({ moduleData, moveVerifyStatus }: ModuleTopProps) => {
           >
             {moduleData.moduleName}
           </Heading>
-          <Tooltip label="This module's verification is supported by its provided source code.">
-            <MoveVerifyBadge status={moveVerifyStatus} />
-          </Tooltip>
+          <MoveVerifyBadge status={moveVerifyStatus} hasTooltip />
         </Flex>
         {!isMobile && (
           <ModuleCta moduleData={moduleData} moduleAddress={moduleAddress} />

--- a/src/lib/pages/modules/index.tsx
+++ b/src/lib/pages/modules/index.tsx
@@ -3,7 +3,12 @@ import { useRouter } from "next/router";
 import { useEffect } from "react";
 
 import { AmpEvent, track } from "lib/amplitude";
-import { useMobile, useMoveConfig, useTierConfig } from "lib/app-provider";
+import {
+  useInitiaL1,
+  useMobile,
+  useMoveConfig,
+  useTierConfig,
+} from "lib/app-provider";
 import PageContainer from "lib/components/PageContainer";
 import { PageHeader } from "lib/components/PageHeader";
 import { CelatoneSeo } from "lib/components/Seo";
@@ -16,6 +21,7 @@ const RecentModules = () => {
   useMoveConfig({ shouldRedirect: true });
   const router = useRouter();
   const isMobile = useMobile();
+  const isInitiaL1 = useInitiaL1({ shouldRedirect: false });
 
   useEffect(() => {
     if (router.isReady) track(AmpEvent.TO_MODULES);
@@ -30,7 +36,7 @@ const RecentModules = () => {
           subtitle=" These modules are the most recently published on this network"
           docHref="move/modules/detail-page"
         />
-        {!isMobile && <ModuleVerificationButton />}
+        {!isMobile && isInitiaL1 && <ModuleVerificationButton />}
       </Flex>
       <RecentModulesTable />
     </PageContainer>

--- a/src/lib/pages/publish-module/completed.tsx
+++ b/src/lib/pages/publish-module/completed.tsx
@@ -3,7 +3,7 @@ import { capitalize } from "lodash";
 import plur from "plur";
 
 import { AmpEvent, track } from "lib/amplitude";
-import { useInternalNavigate } from "lib/app-provider";
+import { useInitiaL1, useInternalNavigate } from "lib/app-provider";
 import ActionPageContainer from "lib/components/ActionPageContainer";
 import { EstimatedFeeRender } from "lib/components/EstimatedFeeRender";
 import { ExplorerLink } from "lib/components/ExplorerLink";
@@ -25,6 +25,7 @@ export const PublishCompleted = ({
   resetState,
 }: PublishCompletedProps) => {
   const navigate = useInternalNavigate();
+  const isInitiaL1 = useInitiaL1({ shouldRedirect: false });
   return (
     <ActionPageContainer>
       <CelatoneSeo pageName="Publish / Republish Modules" />
@@ -58,34 +59,36 @@ export const PublishCompleted = ({
         variant="full"
         my={12}
       />
-      <Flex direction="column" gap={4} w="full" mb={12}>
-        <Heading as="h6" variant="h6">
-          Module Verification
-        </Heading>
-        <Flex
-          w="full"
-          justifyContent="space-between"
-          gap={6}
-          alignItems="center"
-        >
-          <Text variant="body2" color="text.dark">
-            Verifying modules enhances credibility by displaying a verified
-            badge. Once verified, users will be able to access the module&apos;s
-            source code on the details page.
-          </Text>
-          <Button
-            variant="primary"
-            minW={40}
-            onClick={() =>
-              navigate({
-                pathname: "/modules/verify",
-              })
-            }
+      {isInitiaL1 && (
+        <Flex direction="column" gap={4} w="full" mb={12}>
+          <Heading as="h6" variant="h6">
+            Module Verification
+          </Heading>
+          <Flex
+            w="full"
+            justifyContent="space-between"
+            gap={6}
+            alignItems="center"
           >
-            Submit Verification
-          </Button>
+            <Text variant="body2" color="text.dark">
+              Verifying modules enhances credibility by displaying a verified
+              badge. Once verified, users will be able to access the
+              module&apos;s source code on the details page.
+            </Text>
+            <Button
+              variant="primary"
+              minW={40}
+              onClick={() =>
+                navigate({
+                  pathname: "/modules/verify",
+                })
+              }
+            >
+              Submit Verification
+            </Button>
+          </Flex>
         </Flex>
-      </Flex>
+      )}
       <Flex direction="column" gap={6} w="full">
         <Heading as="h6" variant="h6">
           Published {modules.length} {plur("module", modules.length)}


### PR DESCRIPTION
- Fix task status showing as failed when it should be successful on my module verifications
- Disabled on entry points when using on L2 (modules list, after a module is published)
- Update wording in tooltip for the move verification badge