### PR TITLE
feat: disable move verification on custom rollups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
+- [#1289](https://github.com/alleslabs/celatone-frontend/pull/1289) Disable MOVE verification on custom rollups
 - [#1287](https://github.com/alleslabs/celatone-frontend/pull/1287) Disable WASM verification on custom rollups
 
 ### Improvements

--- a/src/lib/components/move-verify-section/index.tsx
+++ b/src/lib/components/move-verify-section/index.tsx
@@ -1,5 +1,6 @@
-import { Flex } from "@chakra-ui/react";
+import { Flex, Text } from "@chakra-ui/react";
 
+import { useIsApiChain } from "lib/app-provider";
 import { MoveVerifyStatus } from "lib/types";
 
 import { NotVerifiedDetails } from "./NotVerifiedDetails";
@@ -11,6 +12,16 @@ interface MoveVerifySectionProps {
 }
 
 const MoveVerifySectionBody = ({ status }: MoveVerifySectionProps) => {
+  const isApiChain = useIsApiChain({
+    shouldRedirect: false,
+  });
+  if (!isApiChain)
+    return (
+      <Text variant="body2" color="text.dark">
+        Module verification is only available on official networks
+      </Text>
+    );
+
   if (status === MoveVerifyStatus.Verified) {
     return <VerifiedDetails />;
   }

--- a/src/lib/layout/navbar/index.tsx
+++ b/src/lib/layout/navbar/index.tsx
@@ -5,6 +5,7 @@ import type { Dispatch, SetStateAction } from "react";
 import {
   useCurrentChain,
   useEvmConfig,
+  useIsApiChain,
   useMoveConfig,
   usePublicProjectConfig,
   useTierConfig,
@@ -38,6 +39,7 @@ interface NavbarProps {
 const Navbar = observer(({ isExpand, setIsExpand }: NavbarProps) => {
   const { address } = useCurrentChain();
   const { isFullTier, isSequencerTier } = useTierConfig();
+  const isApiChain = useIsApiChain({ shouldRedirect: false });
   const wasm = useWasmConfig({ shouldRedirect: false });
   const move = useMoveConfig({ shouldRedirect: false });
   const evm = useEvmConfig({ shouldRedirect: false });
@@ -80,7 +82,7 @@ const Navbar = observer(({ isExpand, setIsExpand }: NavbarProps) => {
                           slug: "/saved-accounts",
                           icon: "admin" as IconKeys,
                         },
-                        ...getDeviceSubmenuMove(move.enabled),
+                        ...getDeviceSubmenuMove(move.enabled && isApiChain),
                         ...getDeviceSubmenuWasm(wasm.enabled),
                       ],
                     },

--- a/src/lib/layout/navbar/utils.ts
+++ b/src/lib/layout/navbar/utils.ts
@@ -191,8 +191,8 @@ export const getDeviceSubmenuWasm = (isWasm: boolean) =>
       ]
     : [];
 
-export const getDeviceSubmenuMove = (isMove: boolean) =>
-  isMove
+export const getDeviceSubmenuMove = (enabled: boolean) =>
+  enabled
     ? [
         {
           name: "My Past Verification",

--- a/src/lib/pages/modules-verify/index.tsx
+++ b/src/lib/pages/modules-verify/index.tsx
@@ -11,7 +11,12 @@ import { observer } from "mobx-react-lite";
 import { useRouter } from "next/router";
 import { useForm } from "react-hook-form";
 
-import { useCelatoneApp, useMobile, useMoveConfig } from "lib/app-provider";
+import {
+  useCelatoneApp,
+  useIsApiChain,
+  useMobile,
+  useMoveConfig,
+} from "lib/app-provider";
 import { ControllerInput } from "lib/components/forms";
 import { FooterCta } from "lib/components/layouts";
 import { Loading } from "lib/components/Loading";
@@ -202,6 +207,7 @@ export const ModulesVerifyBody = observer(
 
 export const ModulesVerify = () => {
   useMoveConfig({ shouldRedirect: true });
+  useIsApiChain({ shouldRedirect: true });
   const { data: moveVerifyConfig, isLoading } = useMoveVerifyConfig();
 
   if (isLoading) return <Loading />;

--- a/src/lib/pages/my-module-verification-details/index.tsx
+++ b/src/lib/pages/my-module-verification-details/index.tsx
@@ -2,7 +2,7 @@ import { Box, ListItem, Stack, Text, UnorderedList } from "@chakra-ui/react";
 import { observer } from "mobx-react-lite";
 import { useRouter } from "next/router";
 
-import { useMoveConfig } from "lib/app-provider";
+import { useIsApiChain, useMoveConfig } from "lib/app-provider";
 import { Loading } from "lib/components/Loading";
 import PageContainer from "lib/components/PageContainer";
 import { CelatoneSeo } from "lib/components/Seo";
@@ -25,6 +25,7 @@ const MyModuleVerificationDetailsBody = ({ taskId }: { taskId: string }) => {
   const { data, isLoading, error } = useMoveVerifyTaskInfo(taskId, !!taskId);
   const { getMoveVerifyTask } = useMoveVerifyTaskStore();
   const verifyModuleTask = getMoveVerifyTask(taskId);
+  useIsApiChain({ shouldRedirect: true });
   useMoveConfig({ shouldRedirect: true });
 
   if (isLoading) return <Loading />;

--- a/src/lib/pages/my-module-verifications/index.tsx
+++ b/src/lib/pages/my-module-verifications/index.tsx
@@ -1,6 +1,10 @@
 import { Box, Button, Flex, Heading, Text } from "@chakra-ui/react";
 
-import { useInternalNavigate, useMoveConfig } from "lib/app-provider";
+import {
+  useInternalNavigate,
+  useIsApiChain,
+  useMoveConfig,
+} from "lib/app-provider";
 import { CustomIcon } from "lib/components/icon";
 import PageContainer from "lib/components/PageContainer";
 import { CelatoneSeo } from "lib/components/Seo";
@@ -10,6 +14,7 @@ import { MyModuleVerificationsTable } from "./components/my-module-verifications
 
 export const MyModuleVerifications = () => {
   const navigate = useInternalNavigate();
+  useIsApiChain({ shouldRedirect: true });
   useMoveConfig({ shouldRedirect: true });
 
   return (

--- a/src/lib/pages/publish-module/completed.tsx
+++ b/src/lib/pages/publish-module/completed.tsx
@@ -3,7 +3,7 @@ import { capitalize } from "lodash";
 import plur from "plur";
 
 import { AmpEvent, track } from "lib/amplitude";
-import { useInternalNavigate } from "lib/app-provider";
+import { useInternalNavigate, useIsApiChain } from "lib/app-provider";
 import ActionPageContainer from "lib/components/ActionPageContainer";
 import { EstimatedFeeRender } from "lib/components/EstimatedFeeRender";
 import { ExplorerLink } from "lib/components/ExplorerLink";
@@ -25,6 +25,7 @@ export const PublishCompleted = ({
   resetState,
 }: PublishCompletedProps) => {
   const navigate = useInternalNavigate();
+  const isApiChain = useIsApiChain({ shouldRedirect: false });
   return (
     <ActionPageContainer>
       <CelatoneSeo pageName="Publish / Republish Modules" />
@@ -58,34 +59,36 @@ export const PublishCompleted = ({
         variant="full"
         my={12}
       />
-      <Flex direction="column" gap={4} w="full" mb={12}>
-        <Heading as="h6" variant="h6">
-          Module Verification
-        </Heading>
-        <Flex
-          w="full"
-          justifyContent="space-between"
-          gap={6}
-          alignItems="center"
-        >
-          <Text variant="body2" color="text.dark">
-            Verifying modules enhances credibility by displaying a verified
-            badge. Once verified, users will be able to access the module&apos;s
-            source code on the details page.
-          </Text>
-          <Button
-            variant="primary"
-            minW={40}
-            onClick={() =>
-              navigate({
-                pathname: "/modules/verify",
-              })
-            }
+      {isApiChain && (
+        <Flex direction="column" gap={4} w="full" mb={12}>
+          <Heading as="h6" variant="h6">
+            Module Verification
+          </Heading>
+          <Flex
+            w="full"
+            justifyContent="space-between"
+            gap={6}
+            alignItems="center"
           >
-            Submit Verification
-          </Button>
+            <Text variant="body2" color="text.dark">
+              Verifying modules enhances credibility by displaying a verified
+              badge. Once verified, users will be able to access the
+              module&apos;s source code on the details page.
+            </Text>
+            <Button
+              variant="primary"
+              minW={40}
+              onClick={() =>
+                navigate({
+                  pathname: "/modules/verify",
+                })
+              }
+            >
+              Submit Verification
+            </Button>
+          </Flex>
         </Flex>
-      </Flex>
+      )}
       <Flex direction="column" gap={6} w="full">
         <Heading as="h6" variant="h6">
           Published {modules.length} {plur("module", modules.length)}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Changelog updated to note the disabling of MOVE verification on custom rollups.

- **New Features**
  - Verification sections now display a network-specific message when accessed on unofficial networks.
  - Navigation menus dynamically adjust to show options based on network conditions.
  - Enhanced verification pages provide improved guidance during module verifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->