### PR TITLE
feat: excluding instantiate permission when using initia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
+- [#1291](https://github.com/alleslabs/celatone-frontend/pull/1291) Exclude instantiate permission from upload access if using Initia
 - [#1284](https://github.com/alleslabs/celatone-frontend/pull/1284) Fix code ID type in form to prevent default 0 value
 - [#1285](https://github.com/alleslabs/celatone-frontend/pull/1285) Enable My Stored Codes in full tier only
 

--- a/src/lib/app-provider/tx/storeCode.ts
+++ b/src/lib/app-provider/tx/storeCode.ts
@@ -13,7 +13,7 @@ export interface StoreCodeStreamParams {
   wasmFileName: Option<string>;
   wasmCode: Option<Promise<ArrayBuffer>>;
   addresses?: BechAddr[];
-  permission: AccessType;
+  permission?: AccessType;
   codeName: string;
   estimatedFee: Option<StdFee>;
   onTxSucceed: StoreCodeSucceedCallback;

--- a/src/lib/components/upload/UploadSection.tsx
+++ b/src/lib/components/upload/UploadSection.tsx
@@ -154,8 +154,9 @@ export const UploadSection = ({
           <Alert variant="primary" mt={3} alignItems="center" gap={3}>
             <CustomIcon name="info-circle" boxSize={4} color="primary.main" />
             <AlertDescription>
-              The instantiate permission is set to the default when deploying
-              through Scan. To customize permissions, deploy via the CLI.
+              The CosmWasm instantiate permission is set to the default when
+              deploying through Initia Scan. To customize permissions, deploy
+              via the CLI.
             </AlertDescription>
           </Alert>
         </Box>

--- a/src/lib/components/upload/UploadSection.tsx
+++ b/src/lib/components/upload/UploadSection.tsx
@@ -1,13 +1,21 @@
-import { Box, Flex, Heading, Text } from "@chakra-ui/react";
+import {
+  Alert,
+  AlertDescription,
+  Box,
+  Flex,
+  Heading,
+  Text,
+} from "@chakra-ui/react";
 import type { StdFee } from "@cosmjs/stargate";
 import { useCallback, useEffect, useState } from "react";
 import type { UseFormReturn } from "react-hook-form";
 
-import { useCelatoneApp, useCurrentChain } from "lib/app-provider";
+import { useCelatoneApp, useCurrentChain, useInitia } from "lib/app-provider";
 import { EstimatedFeeRender } from "lib/components/EstimatedFeeRender";
 import { useGetMaxLengthError } from "lib/hooks";
 import { useDerivedWasmVerifyInfo } from "lib/services/verification/wasm";
-import { WasmVerifyStatus } from "lib/types";
+import { useUploadAccessParamsRest } from "lib/services/wasm/code";
+import { AccessConfigPermission, WasmVerifyStatus } from "lib/types";
 import type {
   BechAddr,
   Option,
@@ -23,6 +31,8 @@ import { SimulateMessageRender } from "./SimulateMessageRender";
 import { UploadCard } from "./UploadCard";
 import { DropZone } from "../dropzone";
 import { ControllerInput } from "../forms";
+import { CustomIcon } from "../icon";
+import { PermissionChip } from "../PermissionChip";
 
 interface UploadSectionProps {
   formData: UseFormReturn<UploadSectionState>;
@@ -43,6 +53,8 @@ export const UploadSection = ({
   simulateStatus,
   isSimulating,
 }: UploadSectionProps) => {
+  const isInitia = useInitia();
+  const { data: uploadAccessParams } = useUploadAccessParamsRest();
   const { constants } = useCelatoneApp();
   const getMaxLengthError = useGetMaxLengthError();
   const { address } = useCurrentChain();
@@ -125,20 +137,44 @@ export const UploadSection = ({
           relatedVerifiedCodes={derivedWasmVerifyInfo?.relatedVerifiedCodes}
         />
       )}
-      <Flex direction="column">
-        <Heading as="h6" variant="h6" fontWeight={600} my={2}>
-          Instantiate Permission
-        </Heading>
-        <Text color="text.dark" variant="body2" mb={4}>
-          Specify who has the authority to instantiate the contract using this
-          code
-        </Text>
-        <InstantiatePermissionRadio
-          control={control}
-          setValue={setValue}
-          trigger={trigger}
-        />
-      </Flex>
+      {isInitia ? (
+        <Box>
+          <Flex alignItems="center" gap={2}>
+            <Heading as="h6" variant="h6" fontWeight={600} my={2}>
+              Instantiate Permission:
+            </Heading>
+            <PermissionChip
+              instantiatePermission={
+                uploadAccessParams?.instantiateDefaultPermission ??
+                AccessConfigPermission.EVERYBODY
+              }
+              permissionAddresses={[]}
+            />
+          </Flex>
+          <Alert variant="primary" mt={3} alignItems="center" gap={3}>
+            <CustomIcon name="info-circle" boxSize={4} color="primary.main" />
+            <AlertDescription>
+              The instantiate permission is set to the default when deploying
+              through Scan. To customize permissions, deploy via the CLI.
+            </AlertDescription>
+          </Alert>
+        </Box>
+      ) : (
+        <Flex direction="column">
+          <Heading as="h6" variant="h6" fontWeight={600} my={2}>
+            Instantiate Permission
+          </Heading>
+          <Text color="text.dark" variant="body2" mb={4}>
+            Specify who has the authority to instantiate the contract using this
+            code
+          </Text>
+          <InstantiatePermissionRadio
+            control={control}
+            setValue={setValue}
+            trigger={trigger}
+          />
+        </Flex>
+      )}
       <Box width="full">
         {(simulateStatus.status !== "default" || isSimulating) && (
           <SimulateMessageRender

--- a/src/lib/hooks/useUploadCode.ts
+++ b/src/lib/hooks/useUploadCode.ts
@@ -8,6 +8,7 @@ import {
   useCelatoneApp,
   useCurrentChain,
   useFabricateFee,
+  useInitia,
   useStoreCodeTx,
   useValidateAddress,
 } from "lib/app-provider";
@@ -32,6 +33,7 @@ export const useUploadCode = (
   const { updateCodeInfo } = useCodeStore();
   const storeCodeTx = useStoreCodeTx(isMigrate);
   const { address } = useCurrentChain();
+  const isInitia = useInitia();
   const {
     chainConfig: {
       extra: { disableAnyOfAddresses },
@@ -91,7 +93,7 @@ export const useUploadCode = (
   const { isFetching: isSimulating } = useSimulateFeeForStoreCode({
     enabled: Boolean(wasmFile && address && !shouldNotSimulate),
     wasmFile,
-    permission,
+    permission: isInitia ? undefined : permission,
     // Remarks: disableAnyOfAddresses is only used for Cosmos SDK 0.26
     addresses: disableAnyOfAddresses
       ? undefined
@@ -130,7 +132,11 @@ export const useUploadCode = (
         addresses: disableAnyOfAddresses
           ? undefined
           : addresses.map((addr) => addr.address),
-        permission,
+        // Remarks: There's a bug when signing an Amino message including the permission field.
+        // Therefore, we decided not to include the permission field when deploying through Scan.
+        // To customize permissions, deploy via the CLI.
+        // If permission is undefined, the default permission is set to 'everybody'.
+        permission: isInitia ? undefined : permission,
         codeName,
         estimatedFee,
         onTxSucceed: (txResult) => {
@@ -157,6 +163,7 @@ export const useUploadCode = (
     updateCodeInfo,
     onComplete,
     disableAnyOfAddresses,
+    isInitia,
     // eslint-disable-next-line react-hooks/exhaustive-deps
     JSON.stringify(addresses),
   ]);

--- a/src/lib/pages/deploy/index.tsx
+++ b/src/lib/pages/deploy/index.tsx
@@ -59,7 +59,7 @@ const Deploy = () => {
 
   const enableUpload =
     !data?.isPermissionedNetwork ||
-    Boolean(address && data?.addresses?.includes(address));
+    Boolean(address && data?.codeUploadAccess.addresses?.includes(address));
 
   useWasmConfig({ shouldRedirect: true });
 

--- a/src/lib/pages/migrate/components/MigrateOptions.tsx
+++ b/src/lib/pages/migrate/components/MigrateOptions.tsx
@@ -29,8 +29,8 @@ export const MigrateOptions = ({
     !uploadAccessParams?.isPermissionedNetwork ||
     resolvePermission(
       address,
-      uploadAccessParams?.permission,
-      uploadAccessParams?.addresses
+      uploadAccessParams?.codeUploadAccess.permission,
+      uploadAccessParams?.codeUploadAccess.addresses
     );
   return (
     <>

--- a/src/lib/pages/proposal/whitelist/index.tsx
+++ b/src/lib/pages/proposal/whitelist/index.tsx
@@ -131,7 +131,10 @@ const ProposalToWhitelist = () => {
           permission: uploadAccessParams?.isPermissionedNetwork
             ? AccessConfigPermission.ANY_OF_ADDRESSES
             : AccessConfigPermission.EVERYBODY,
-          addresses: uploadAccessParams?.addresses?.concat(addressesArray),
+          addresses:
+            uploadAccessParams?.codeUploadAccess.addresses?.concat(
+              addressesArray
+            ),
         }),
         initialDeposit,
         proposer: walletAddress,
@@ -333,7 +336,7 @@ const ProposalToWhitelist = () => {
                             addressObj.address === addresses[idx].address
                         ) && "You already input this address",
                       whitelisted: () =>
-                        uploadAccessParams?.addresses?.includes(
+                        uploadAccessParams?.codeUploadAccess.addresses?.includes(
                           addresses[idx].address
                         )
                           ? "This address is already included in whitelist"

--- a/src/lib/pages/stored-codes/index.tsx
+++ b/src/lib/pages/stored-codes/index.tsx
@@ -56,7 +56,9 @@ const StoredCodes = observer(() => {
   const { data, isFetching: isUploadAccessFetching } =
     useUploadAccessParamsRest();
 
-  const isAllowed = Boolean(address && data?.addresses?.includes(address));
+  const isAllowed = Boolean(
+    address && data?.codeUploadAccess.addresses?.includes(address)
+  );
 
   useEffect(() => {
     if (router.isReady) track(AmpEvent.TO_MY_STORED_CODES);

--- a/src/lib/pages/upload/upload.tsx
+++ b/src/lib/pages/upload/upload.tsx
@@ -39,7 +39,7 @@ export const Upload = ({
 
   const enableUpload =
     !data?.isPermissionedNetwork ||
-    (address && Boolean(data?.addresses?.includes(address)));
+    (address && Boolean(data?.codeUploadAccess.addresses?.includes(address)));
 
   useEffect(() => {
     // Redirect back to deploy page

--- a/src/lib/services/tx/simulateFee.ts
+++ b/src/lib/services/tx/simulateFee.ts
@@ -64,7 +64,7 @@ export const useSimulateFeeQuery = ({
 interface SimulateQueryParamsForStoreCode {
   enabled: boolean;
   wasmFile: Option<File>;
-  permission: AccessType;
+  permission?: AccessType;
   addresses?: BechAddr[];
   onSuccess?: (gas: Option<Gas>) => void;
   onError?: (err: Error) => void;

--- a/src/lib/services/types/wasm/code.ts
+++ b/src/lib/services/types/wasm/code.ts
@@ -11,37 +11,20 @@ import {
 } from "lib/types";
 import { parseTxHash, snakeToCamel } from "lib/utils";
 
-const zUploadAccessParams = z
+export const zUploadAccessParams = z
   .object({
-    permission: z.nativeEnum(AccessConfigPermission),
-    addresses: zBechAddr.array(),
+    code_upload_access: z.object({
+      permission: z.nativeEnum(AccessConfigPermission),
+      addresses: zBechAddr.array(),
+    }),
+    instantiate_default_permission: z.nativeEnum(AccessConfigPermission),
   })
   .transform((val) => ({
-    isPermissionedNetwork: val.permission !== AccessConfigPermission.EVERYBODY,
-    ...val,
+    isPermissionedNetwork:
+      val.code_upload_access.permission !== AccessConfigPermission.EVERYBODY,
+    ...snakeToCamel(val),
   }));
 export type UploadAccessParams = z.infer<typeof zUploadAccessParams>;
-
-export const zUploadAccessParamsRest = z
-  .object({
-    params: z.object({
-      code_upload_access: zUploadAccessParams,
-    }),
-  })
-  .transform<UploadAccessParams>((val) => val.params.code_upload_access);
-
-export const zUploadAccessParamsSubspaceRest = z
-  .object({
-    params: z.object({
-      subspace: z.literal("wasm"),
-      key: z.literal("uploadAccess"),
-      value: z
-        .string()
-        .transform((val) => JSON.parse(val))
-        .pipe(zUploadAccessParams),
-    }),
-  })
-  .transform<UploadAccessParams>((val) => val.params.value);
 
 const zCodesResponseItem = z
   .object({

--- a/src/lib/services/wasm/code/rest.ts
+++ b/src/lib/services/wasm/code/rest.ts
@@ -4,29 +4,19 @@ import type { UploadAccessParams } from "lib/services/types";
 import {
   zCodeInfoResponseRest,
   zCodesResponseRest,
-  zUploadAccessParamsRest,
-  zUploadAccessParamsSubspaceRest,
+  zUploadAccessParams,
 } from "lib/services/types";
 import type { Option } from "lib/types";
 import { parseWithError } from "lib/utils";
 
-export const getUploadAccessParamsRest = async (
+export const getUploadAccessParamsRest = (
   restEndpoint: string
-): Promise<UploadAccessParams> => {
-  const res = await axios.get(`${restEndpoint}/cosmwasm/wasm/v1/codes/params`);
-  const validated = zUploadAccessParamsRest.safeParse(res.data);
-  if (res.status === 200 && validated.success) return validated.data;
+): Promise<UploadAccessParams> =>
+  axios
+    .get(`${restEndpoint}/cosmwasm/wasm/v1/codes/params`)
+    .then(({ data }) => parseWithError(zUploadAccessParams, data));
 
-  const res2 = await axios.get(`${restEndpoint}/wasm/v1beta1/params`);
-  const validated2 = zUploadAccessParamsSubspaceRest.safeParse(res2.data);
-  if (res2.status === 200 && validated2.success) return validated2.data;
-  throw new Error("Failed to fetch upload access params");
-};
-
-export const getCodesRest = async (
-  endpoint: string,
-  paginationKey: Option<string>
-) =>
+export const getCodesRest = (endpoint: string, paginationKey: Option<string>) =>
   axios
     .get(`${endpoint}/cosmwasm/wasm/v1/code`, {
       params: {
@@ -37,7 +27,7 @@ export const getCodesRest = async (
     })
     .then(({ data }) => parseWithError(zCodesResponseRest, data));
 
-export const getCodeRest = async (endpoint: string, codeId: number) =>
+export const getCodeRest = (endpoint: string, codeId: number) =>
   axios
     .get(`${endpoint}/cosmwasm/wasm/v1/code/${encodeURIComponent(codeId)}`)
     .then(({ data }) => parseWithError(zCodeInfoResponseRest, data));

--- a/src/lib/utils/tx/composeMsg.ts
+++ b/src/lib/utils/tx/composeMsg.ts
@@ -40,7 +40,7 @@ export const composeMsg = (msgType: MsgType, msg: TxMessage): ComposedMsg => {
 interface StoreCodeMsgArgs {
   sender: BechAddr20;
   wasmByteCode: Uint8Array;
-  permission: AccessType;
+  permission?: AccessType;
   addresses?: BechAddr[];
 }
 
@@ -53,11 +53,13 @@ export const composeStoreCodeMsg = ({
   composeMsg(MsgType.STORE_CODE, {
     sender,
     wasmByteCode,
-    instantiatePermission: {
-      permission,
-      addresses,
-      address: "" as BechAddr,
-    },
+    instantiatePermission: permission
+      ? {
+          permission,
+          addresses,
+          address: "" as BechAddr,
+        }
+      : undefined,
   });
 
 interface WhitelistProposalMsgArgs {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The upload interface now adapts based on your usage mode. When using Initia, you’ll see a contextual alert and a permission indicator informing you of the default instantiate settings.

- **Improvements**
  - Upload access now automatically excludes instantiate permission for Initia users.
  - Permission checks have been refined across deployment, migration, and whitelist processes.
  - Documentation has been updated to clearly explain these access changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->