### PR TITLE
Fix openTxTab when no tx hash

### DIFF
--- a/src/lib/hooks/useOpenTab.ts
+++ b/src/lib/hooks/useOpenTab.ts
@@ -43,6 +43,7 @@ export const useOpenTxTab = (type: "rest" | "tx-page") => {
 
   return useCallback(
     (txHash: Option<string>) => {
+      if (!txHash) return;
       openNewTab(`${baseUrl}/${txHash}`);
     },
     [baseUrl]


### PR DESCRIPTION
## Summary
- handle undefined tx hash in `useOpenTxTab`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684542ac4508832f9527b979e218d1b3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when opening transaction tabs by preventing attempts to open tabs with invalid or empty transaction hashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->