### PR TITLE
fix: showing dash for zero value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
+- [#1346](https://github.com/alleslabs/celatone-frontend/pull/1346) Show $- for zero value instead
+
 ### Bug fixes
 
 - [#1343](https://github.com/alleslabs/celatone-frontend/pull/1343) Fix upgrade policy issue when publishing a module

--- a/src/lib/utils/formatter/token.test.ts
+++ b/src/lib/utils/formatter/token.test.ts
@@ -260,10 +260,10 @@ describe("formatPrice", () => {
   });
   describe("if 0, use 2 decimal points", () => {
     test("from string", () => {
-      expect(formatPrice("0" as USD)).toEqual("$0.00");
+      expect(formatPrice("0" as USD)).toEqual("$ - ");
     });
     test("from number", () => {
-      expect(formatPrice(0 as USD<number>)).toEqual("$0.00");
+      expect(formatPrice(0 as USD<number>)).toEqual("$ - ");
     });
   });
   describe("> 1", () => {

--- a/src/lib/utils/formatter/token.ts
+++ b/src/lib/utils/formatter/token.ts
@@ -105,7 +105,7 @@ export const formatUTokenWithPrecision = (
  */
 export const formatPrice = (value: USD<BigSource>): string => {
   try {
-    if (value === big(0)) return "$-";
+    if (big(value).eq(0)) return "$ - ";
 
     const price = big(value);
     const lowestThreshold = 0.000001;

--- a/src/lib/utils/formatter/token.ts
+++ b/src/lib/utils/formatter/token.ts
@@ -105,6 +105,8 @@ export const formatUTokenWithPrecision = (
  */
 export const formatPrice = (value: USD<BigSource>): string => {
   try {
+    if (value === big(0)) return "$-";
+
     const price = big(value);
     const lowestThreshold = 0.000001;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Zero values are now displayed as "$-" instead of the previous format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->