### PR TITLE
feat: remove unused move upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
+- [#1347](https://github.com/alleslabs/celatone-frontend/pull/1347) Remove unused is move upgraded flag
 - [#1346](https://github.com/alleslabs/celatone-frontend/pull/1346) Show $- for zero value instead
 
 ### Bug fixes

--- a/src/lib/data/constant.ts
+++ b/src/lib/data/constant.ts
@@ -64,7 +64,6 @@ export const DEFAULT_MOVE_TX_FILTERS: MoveTxFilters = {
   isMoveExecute: false,
   isMovePublish: false,
   isMoveScript: false,
-  isMoveUpgrade: false,
 };
 
 export const DEFAULT_INITIA_TX_FILTERS: InitiaTxFilters = {

--- a/src/lib/services/types/tx.ts
+++ b/src/lib/services/types/tx.ts
@@ -350,7 +350,6 @@ const zBaseTxsResponseItem = z.object({
   is_move_execute: z.boolean().optional(),
   is_move_publish: z.boolean().optional(),
   is_move_script: z.boolean().optional(),
-  is_move_upgrade: z.boolean().optional(),
   // initia
   is_opinit: z.boolean().optional(),
   is_send: z.boolean(),
@@ -421,7 +420,6 @@ const zAccountTxsResponseItem = zBaseTxsResponseItem
         isMoveExecute: val.is_move_execute,
         isMovePublish: val.is_move_publish,
         isMoveScript: val.is_move_script,
-        isMoveUpgrade: val.is_move_upgrade,
         isSend: val.is_send,
         isStoreCode: val.is_store_code,
         isUpdateAdmin: val.is_update_admin,

--- a/src/lib/types/tx/transaction.ts
+++ b/src/lib/types/tx/transaction.ts
@@ -70,7 +70,6 @@ export interface MoveTxFilters {
   isMoveExecute: boolean;
   isMovePublish: boolean;
   isMoveScript: boolean;
-  isMoveUpgrade: boolean;
 }
 
 export interface TxFilters

--- a/src/lib/utils/extractActionValue.ts
+++ b/src/lib/utils/extractActionValue.ts
@@ -16,8 +16,6 @@ export const displayActionValue = (isActionName: string) => {
       return "Publish module";
     case "isMoveScript":
       return "Run script";
-    case "isMoveUpgrade":
-      return "Upgrade module";
     case "isOpinit":
       return "OPInit";
     case "isSend":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Removed the unused "is move upgraded" filter and related references from transaction filters and display logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->