### PR TITLE
Fix Typo in Variable Name in ViewPermissionAddresses Component

### DIFF
--- a/src/lib/components/ViewPermissionAddresses.tsx
+++ b/src/lib/components/ViewPermissionAddresses.tsx
@@ -17,14 +17,14 @@ export const ViewPermissionAddresses = ({
 }) => {
   const [viewAll, setViewAll] = useState(false);
   const getAddressType = useGetAddressType();
-  const showAddressses =
+  const showAddresses =
     viewAll ||
     (typeof permissionAddresses === "object" &&
       permissionAddresses.length === 1);
 
   return (
     <>
-      {showAddressses &&
+      {showAddresses &&
         permissionAddresses.map((addr) => (
           <ExplorerLink
             key={addr}


### PR DESCRIPTION


**Description:**  
This pull request corrects a typo in the variable name from showAddressses to showAddresses within the ViewPermissionAddresses component for improved code clarity and consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo to ensure permission addresses display correctly when toggled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->