### PR TITLE
fix(types): nft sequencer

### DIFF
--- a/src/lib/services/types/nft.ts
+++ b/src/lib/services/types/nft.ts
@@ -3,7 +3,6 @@ import type { MutateEvent } from "lib/types";
 import {
   zAddr,
   zBechAddr,
-  zHexAddr,
   zHexAddr20,
   zHexAddr32,
   zPagination,
@@ -114,7 +113,11 @@ const zNftSequencer = z
       uri: z.string(),
     }),
     object_addr: zHexAddr32,
-    owner_addr: zHexAddr,
+    owner: zAddr.optional(),
+    owner_addr: zAddr.optional(),
+  })
+  .refine((val) => val.owner || val.owner_addr, {
+    message: "Either owner or owner_addr must be present",
   })
   .transform<Nft>((val) => ({
     collectionAddress: val.collection_addr,
@@ -122,7 +125,7 @@ const zNftSequencer = z
     description: val.nft.description,
     isBurned: false,
     nftAddress: val.object_addr ? val.object_addr : null,
-    ownerAddress: val.owner_addr,
+    ownerAddress: (val.owner_addr ?? val.owner)!,
     tokenId: val.nft.token_id,
     uri: val.nft.uri,
   }));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Standardized NFT owner input to support two optional owner fields and derive the canonical owner address from the new owner field when present.
  - Update integrations to handle either owner field.

- Bug Fixes
  - Collection origin name is now optional to avoid failures when missing.
  - Validation added to require at least one owner field be provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->