### PR TITLE
feat(components): remove evm txs table price label

### DIFF
--- a/src/lib/components/table/evm-transactions/EvmTransactionsTableMobileCard.tsx
+++ b/src/lib/components/table/evm-transactions/EvmTransactionsTableMobileCard.tsx
@@ -11,14 +11,12 @@ import {
   coinToTokenWithValue,
   dateFromNow,
   formatEvmTxHash,
-  formatPrice,
   formatUTC,
   formatUTokenWithPrecision,
   getEvmAmount,
   getEvmToAddress,
   getTokenLabel,
 } from "lib/utils";
-import { isUndefined } from "lodash";
 
 import { MobileCardTemplate } from "../MobileCardTemplate";
 import { MobileLabel } from "../MobileLabel";
@@ -82,11 +80,6 @@ export const EvmTransactionsTableMobileCard = ({
                 </Text>
                 {getTokenLabel(token.denom, token.symbol)}
               </Text>
-              {!isUndefined(token.value) && (
-                <Text color="text.dark" variant="body3">
-                  ({formatPrice(token.value)})
-                </Text>
-              )}
             </Flex>
           </Flex>
         </Stack>

--- a/src/lib/components/table/evm-transactions/EvmTransactionsTableRow.tsx
+++ b/src/lib/components/table/evm-transactions/EvmTransactionsTableRow.tsx
@@ -11,14 +11,12 @@ import {
   coinToTokenWithValue,
   dateFromNow,
   formatEvmTxHash,
-  formatPrice,
   formatUTC,
   formatUTokenWithPrecision,
   getEvmAmount,
   getEvmToAddress,
   getTokenLabel,
 } from "lib/utils";
-import { isUndefined } from "lodash";
 
 import { TableRow } from "../tableComponents";
 
@@ -107,11 +105,6 @@ export const EvmTransactionsTableRow = ({
           </Text>
           {getTokenLabel(token.denom, token.symbol)}
         </Text>
-        {!isUndefined(token.value) && (
-          <Text color="text.dark" variant="body3">
-            ({formatPrice(token.value)})
-          </Text>
-        )}
       </TableRow>
       {showTimestamp && (
         <TableRow>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Simplified EVM Transactions tables by removing the token price/value display next to amounts in both mobile cards and desktop rows.
  - Amounts now show only the precise quantity and token label, improving readability and reducing visual clutter.
  - No changes to sorting, filtering, or other table behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->