### PR TITLE
feat(utils): apply glyph image to nft

### DIFF
--- a/src/lib/services/nft/api.ts
+++ b/src/lib/services/nft/api.ts
@@ -1,7 +1,6 @@
-import type { Addr, HexAddr, HexAddr32 } from "lib/types";
+import type { HexAddr, HexAddr32 } from "lib/types";
 
 import axios from "axios";
-import { GLYPH_API_URL } from "env";
 import { parseWithError } from "lib/utils";
 
 import {
@@ -85,26 +84,6 @@ export const getMetadata = async (uri: string) => {
     throw error;
   }
 };
-
-export const getGlyphImage = (
-  chainId: string,
-  collectionAddress: Addr,
-  objectAddress: string,
-  width?: string,
-  height?: string
-) =>
-  axios
-    .get<Blob>(
-      `${GLYPH_API_URL}/${chainId}/${collectionAddress}/${objectAddress}`,
-      {
-        params: {
-          height,
-          width,
-        },
-        responseType: "blob",
-      }
-    )
-    .then(({ data }) => data);
 
 export const getNftTxs = async (
   endpoint: string,

--- a/src/lib/services/nft/index.ts
+++ b/src/lib/services/nft/index.ts
@@ -1,6 +1,7 @@
 import type { UseQueryOptions } from "@tanstack/react-query";
 
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { GLYPH_API_URL } from "env";
 import {
   CELATONE_QUERY_KEYS,
   useBaseApiRoute,
@@ -35,9 +36,8 @@ import type {
   NftTxsResponse,
 } from "../types";
 
-import { getIpfsUrl, handleQueryByTier } from "../utils";
+import { handleQueryByTier } from "../utils";
 import {
-  getGlyphImage,
   getMetadata,
   getNftByNftAddress,
   getNftMintInfo,
@@ -333,21 +333,17 @@ export const useMetadata = (
     async () => {
       if (!nft) throw new Error("NFT is required (useMetadata)");
       const baseUri = await getMetadata(nft.uri ?? "");
-      if (baseUri.image && nft.collectionAddress) {
-        try {
-          const image: Blob = await getGlyphImage(
-            currentChainId,
-            nft.collectionAddress,
-            nft.nftAddress ?? nft.tokenId ?? "",
-            width,
-            height
-          );
 
-          baseUri.image = URL.createObjectURL(image);
-        } catch {
-          baseUri.image = getIpfsUrl(baseUri.image);
-        }
-      }
+      const params = new URLSearchParams();
+      if (width) params.set("width", width);
+      if (height) params.set("height", height);
+
+      const objectAddress =
+        nft.nftAddress && nft.nftAddress !== "0x"
+          ? nft.nftAddress
+          : (nft.tokenId ?? "");
+
+      baseUri.image = `${GLYPH_API_URL}/${currentChainId}/${nft.collectionAddress}/${objectAddress}${params.toString() ? `?${params}` : ""}`;
 
       return baseUri;
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified NFT image loading to use a single, consistently constructed image URL.
  * Removed fallback logic to alternate image sources, reducing complexity and potential inconsistencies.
  * Eliminated binary image fetching in favor of direct URL usage for potentially faster loads.

* **Chores**
  * Removed an obsolete glyph image retrieval endpoint from the public surface to streamline the NFT service API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->