### PR TITLE
fix(utils): decimal points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+- [#1440](https://github.com/alleslabs/celatone-frontend/pull/1440) Fix decimal points trailing zeros issue
 - [#1438](https://github.com/alleslabs/celatone-frontend/pull/1438) Fix resend button component
 - [#1434](https://github.com/alleslabs/celatone-frontend/pull/1434) Fix balance change tab empty state
 - [#1423](https://github.com/alleslabs/celatone-frontend/pull/1423) Fix message body from L1, and L2

--- a/src/lib/utils/formatter/formatTokenWithValue.test.ts
+++ b/src/lib/utils/formatter/formatTokenWithValue.test.ts
@@ -22,7 +22,7 @@ describe("formatTokenWithValue", () => {
 
     expect(formatTokenWithValue({ token })).toBe("1,000,000 denom");
     expect(formatTokenWithValue({ decimalPoints: 2, token })).toBe(
-      "1,000,000.00 denom"
+      "1,000,000 denom"
     );
   });
 
@@ -38,10 +38,8 @@ describe("formatTokenWithValue", () => {
       value: undefined,
     };
 
-    expect(formatTokenWithValue({ token })).toBe("1.000000 denom");
-    expect(formatTokenWithValue({ decimalPoints: 2, token })).toBe(
-      "1.00 denom"
-    );
+    expect(formatTokenWithValue({ token })).toBe("1 denom");
+    expect(formatTokenWithValue({ decimalPoints: 2, token })).toBe("1 denom");
   });
 
   test("coin with symbol", () => {
@@ -58,7 +56,7 @@ describe("formatTokenWithValue", () => {
 
     expect(formatTokenWithValue({ token })).toBe("1,000,000 CLTN");
     expect(formatTokenWithValue({ decimalPoints: 2, token })).toBe(
-      "1,000,000.00 CLTN"
+      "1,000,000 CLTN"
     );
   });
 
@@ -74,8 +72,8 @@ describe("formatTokenWithValue", () => {
       value: undefined,
     };
 
-    expect(formatTokenWithValue({ token })).toBe("1.000000 CLTN");
-    expect(formatTokenWithValue({ decimalPoints: 2, token })).toBe("1.00 CLTN");
+    expect(formatTokenWithValue({ token })).toBe("1 CLTN");
+    expect(formatTokenWithValue({ decimalPoints: 2, token })).toBe("1 CLTN");
   });
 });
 
@@ -118,18 +116,18 @@ describe("formatTokenWithValueList", () => {
   });
 
   test("1 token", () => {
-    expect(formatTokenWithValueList(tokens.slice(0, 1))).toBe("1.00 CLTN1");
+    expect(formatTokenWithValueList(tokens.slice(0, 1))).toBe("1 CLTN1");
   });
 
   test("2 tokens", () => {
     expect(formatTokenWithValueList(tokens.slice(0, 2))).toBe(
-      "1.00 CLTN1 and 2.00 CLTN2"
+      "1 CLTN1 and 2 CLTN2"
     );
   });
 
   test("more than 2 tokens", () => {
     expect(formatTokenWithValueList(tokens)).toBe(
-      "1.00 CLTN1, 2.00 CLTN2, and 3.00 CLTN3"
+      "1 CLTN1, 2 CLTN2, and 3 CLTN3"
     );
   });
 });

--- a/src/lib/utils/formatter/token.test.ts
+++ b/src/lib/utils/formatter/token.test.ts
@@ -36,73 +36,73 @@ describe("formatDecimal", () => {
   });
 
   test("from string", () => {
-    expect(f("12345678", FALLBACK)).toEqual("12345678.0000");
-    expect(f("12345.678", FALLBACK)).toEqual("12345.6780");
+    expect(f("12345678", FALLBACK)).toEqual("12345678");
+    expect(f("12345.678", FALLBACK)).toEqual("12345.678");
 
-    expect(f("-12345678", FALLBACK)).toEqual("-12345678.0000");
-    expect(f("-12345.678", FALLBACK)).toEqual("-12345.6780");
+    expect(f("-12345678", FALLBACK)).toEqual("-12345678");
+    expect(f("-12345.678", FALLBACK)).toEqual("-12345.678");
 
-    expect(fDelim("00.000", FALLBACK)).toEqual("0.0000");
-    expect(fDelim("0.0000001", FALLBACK)).toEqual("0.0000");
-    expect(fDelim("0.123", FALLBACK)).toEqual("0.1230");
-    expect(fDelim("123", FALLBACK)).toEqual("123.0000");
-    expect(fDelim("01234", FALLBACK)).toEqual("1,234.0000");
-    expect(fDelim("12340", FALLBACK)).toEqual("12,340.0000");
-    expect(fDelim("12345678", FALLBACK)).toEqual("12,345,678.0000");
-    expect(fDelim("12345.678", FALLBACK)).toEqual("12,345.6780");
+    expect(fDelim("00.000", FALLBACK)).toEqual("0");
+    expect(fDelim("0.0000001", FALLBACK)).toEqual("0");
+    expect(fDelim("0.123", FALLBACK)).toEqual("0.123");
+    expect(fDelim("123", FALLBACK)).toEqual("123");
+    expect(fDelim("01234", FALLBACK)).toEqual("1,234");
+    expect(fDelim("12340", FALLBACK)).toEqual("12,340");
+    expect(fDelim("12345678", FALLBACK)).toEqual("12,345,678");
+    expect(fDelim("12345.678", FALLBACK)).toEqual("12,345.678");
     expect(fDelim("123.45678", FALLBACK)).toEqual("123.4567");
 
-    expect(fDelim("-0", FALLBACK)).toEqual("0.0000");
-    expect(fDelim("-0.0000001", FALLBACK)).toEqual("0.0000");
-    expect(fDelim("-0.123", FALLBACK)).toEqual("-0.1230");
-    expect(fDelim("-01.230", FALLBACK)).toEqual("-1.2300");
-    expect(fDelim("-123", FALLBACK)).toEqual("-123.0000");
-    expect(fDelim("-01234", FALLBACK)).toEqual("-1,234.0000");
-    expect(fDelim("-12340", FALLBACK)).toEqual("-12,340.0000");
-    expect(fDelim("-12345678", FALLBACK)).toEqual("-12,345,678.0000");
-    expect(fDelim("-12345.678", FALLBACK)).toEqual("-12,345.6780");
+    expect(fDelim("-0", FALLBACK)).toEqual("0");
+    expect(fDelim("-0.0000001", FALLBACK)).toEqual("0");
+    expect(fDelim("-0.123", FALLBACK)).toEqual("-0.123");
+    expect(fDelim("-01.230", FALLBACK)).toEqual("-1.23");
+    expect(fDelim("-123", FALLBACK)).toEqual("-123");
+    expect(fDelim("-01234", FALLBACK)).toEqual("-1,234");
+    expect(fDelim("-12340", FALLBACK)).toEqual("-12,340");
+    expect(fDelim("-12345678", FALLBACK)).toEqual("-12,345,678");
+    expect(fDelim("-12345.678", FALLBACK)).toEqual("-12,345.678");
     expect(fDelim("-123.45678", FALLBACK)).toEqual("-123.4567");
   });
 
   test("from number", () => {
-    expect(f(0xab, FALLBACK)).toEqual("171.0000");
-    expect(f(1e2, FALLBACK)).toEqual("100.0000");
-    expect(f(0b111, FALLBACK)).toEqual("7.0000");
+    expect(f(0xab, FALLBACK)).toEqual("171");
+    expect(f(1e2, FALLBACK)).toEqual("100");
+    expect(f(0b111, FALLBACK)).toEqual("7");
 
-    expect(f(12345678, FALLBACK)).toEqual("12345678.0000");
-    expect(f(12345.678, FALLBACK)).toEqual("12345.6780");
+    expect(f(12345678, FALLBACK)).toEqual("12345678");
+    expect(f(12345.678, FALLBACK)).toEqual("12345.678");
 
-    expect(f(-12345678, FALLBACK)).toEqual("-12345678.0000");
-    expect(f(-12345.678, FALLBACK)).toEqual("-12345.6780");
+    expect(f(-12345678, FALLBACK)).toEqual("-12345678");
+    expect(f(-12345.678, FALLBACK)).toEqual("-12345.678");
 
-    expect(fDelim(0, FALLBACK)).toEqual("0.0000");
-    expect(fDelim(0.123, FALLBACK)).toEqual("0.1230");
-    expect(fDelim(123, FALLBACK)).toEqual("123.0000");
-    expect(fDelim(12340, FALLBACK)).toEqual("12,340.0000");
-    expect(fDelim(12345678, FALLBACK)).toEqual("12,345,678.0000");
-    expect(fDelim(12345.678, FALLBACK)).toEqual("12,345.6780");
+    expect(fDelim(0, FALLBACK)).toEqual("0");
+    expect(fDelim(0.123, FALLBACK)).toEqual("0.123");
+    expect(fDelim(123, FALLBACK)).toEqual("123");
+    expect(fDelim(12340, FALLBACK)).toEqual("12,340");
+    expect(fDelim(12345678, FALLBACK)).toEqual("12,345,678");
+    expect(fDelim(12345.678, FALLBACK)).toEqual("12,345.678");
     expect(fDelim(123.45678, FALLBACK)).toEqual("123.4567");
 
-    expect(fDelim(-0, FALLBACK)).toEqual("0.0000");
-    expect(fDelim(-0.123, FALLBACK)).toEqual("-0.1230");
-    expect(fDelim(-123, FALLBACK)).toEqual("-123.0000");
-    expect(fDelim(-12340, FALLBACK)).toEqual("-12,340.0000");
-    expect(fDelim(-12345678, FALLBACK)).toEqual("-12,345,678.0000");
-    expect(fDelim(-12345.678, FALLBACK)).toEqual("-12,345.6780");
+    expect(fDelim(-0, FALLBACK)).toEqual("0");
+    expect(fDelim(-0.123, FALLBACK)).toEqual("-0.123");
+    expect(fDelim(-123, FALLBACK)).toEqual("-123");
+    expect(fDelim(-12340, FALLBACK)).toEqual("-12,340");
+    expect(fDelim(-12345678, FALLBACK)).toEqual("-12,345,678");
+    expect(fDelim(-12345.678, FALLBACK)).toEqual("-12,345.678");
     expect(fDelim(-123.45678, FALLBACK)).toEqual("-123.4567");
   });
 
   test("from big", () => {
-    expect(f(big(1234), FALLBACK)).toEqual("1234.0000");
-    expect(f(big(123456.789), FALLBACK)).toEqual("123456.7890");
+    expect(f(big(1234), FALLBACK)).toEqual("1234");
+    expect(f(big(123456.789), FALLBACK)).toEqual("123456.789");
 
-    expect(f(big(-123456789), FALLBACK)).toEqual("-123456789.0000");
-    expect(f(big(-123456.789), FALLBACK)).toEqual("-123456.7890");
+    expect(f(big(-123456789), FALLBACK)).toEqual("-123456789");
+    expect(f(big(-123456.789), FALLBACK)).toEqual("-123456.789");
 
-    expect(fDelim(big(123456.789), FALLBACK)).toEqual("123,456.7890");
+    expect(fDelim(big(123456.789), FALLBACK)).toEqual("123,456.789");
     expect(fDelim(big(123.456789), FALLBACK)).toEqual("123.4567");
 
-    expect(fDelim(big(-123456.789), FALLBACK)).toEqual("-123,456.7890");
+    expect(fDelim(big(-123456.789), FALLBACK)).toEqual("-123,456.789");
     expect(fDelim(big(-123.456789), FALLBACK)).toEqual("-123.4567");
   });
 });
@@ -125,9 +125,9 @@ describe("d2Formatter", () => {
     expect(d2Formatter("1234.5678", FALLBACK)).toEqual("1,234.56");
   });
   test("from number", () => {
-    expect(d2Formatter(1234.5, FALLBACK)).toEqual("1,234.50");
-    expect(d2Formatter(1234, FALLBACK)).toEqual("1,234.00");
-    expect(d2Formatter(-1234.5, FALLBACK)).toEqual("-1,234.50");
+    expect(d2Formatter(1234.5, FALLBACK)).toEqual("1,234.5");
+    expect(d2Formatter(1234, FALLBACK)).toEqual("1,234");
+    expect(d2Formatter(-1234.5, FALLBACK)).toEqual("-1,234.5");
   });
 });
 
@@ -137,9 +137,9 @@ describe("d6Formatter", () => {
     expect(d6Formatter("-0.123456789", FALLBACK)).toEqual("-0.123456");
   });
   test("from number", () => {
-    expect(d6Formatter(0.1234, FALLBACK)).toEqual("0.123400");
-    expect(d6Formatter(1234, FALLBACK)).toEqual("1,234.000000");
-    expect(d6Formatter(-0.1234, FALLBACK)).toEqual("-0.123400");
+    expect(d6Formatter(0.1234, FALLBACK)).toEqual("0.1234");
+    expect(d6Formatter(1234, FALLBACK)).toEqual("1,234");
+    expect(d6Formatter(-0.1234, FALLBACK)).toEqual("-0.1234");
   });
 });
 
@@ -182,7 +182,7 @@ describe("formatUTokenWithPrecision", () => {
           isSuffix: false,
           precision: 6,
         })
-      ).toEqual("0.000000");
+      ).toEqual("0");
       expect(
         formatUTokenWithPrecision({
           amount: "" as U<Token>,
@@ -190,7 +190,7 @@ describe("formatUTokenWithPrecision", () => {
           isSuffix: true,
           precision: 6,
         })
-      ).toEqual("0.0");
+      ).toEqual("0");
     });
     test("NaN", () => {
       expect(
@@ -199,7 +199,7 @@ describe("formatUTokenWithPrecision", () => {
           isSuffix: false,
           precision: 8,
         })
-      ).toEqual("0.000000");
+      ).toEqual("0");
       expect(
         formatUTokenWithPrecision({
           amount: NaN as U<Token<number>>,
@@ -207,7 +207,7 @@ describe("formatUTokenWithPrecision", () => {
           isSuffix: true,
           precision: 6,
         })
-      ).toEqual("0.000");
+      ).toEqual("0");
     });
   });
   test("too small", () => {
@@ -242,7 +242,7 @@ describe("formatUTokenWithPrecision", () => {
         isSuffix: false,
         precision: 6,
       })
-    ).toEqual("12,345,678,901,234.567890");
+    ).toEqual("12,345,678,901,234.56789");
     expect(
       formatUTokenWithPrecision({
         amount: "12345678901234567890" as U<Token>,
@@ -258,7 +258,7 @@ describe("formatUTokenWithPrecision", () => {
         isSuffix: false,
         precision: 6,
       })
-    ).toEqual("12,345,678,901,234.567890");
+    ).toEqual("12,345,678,901,234.56789");
   });
   describe("with suffix", () => {
     test(">= T", () => {
@@ -342,7 +342,7 @@ describe("formatPrice", () => {
       expect(formatPrice("1.234" as USD)).toEqual("$1.23");
     });
     test("from number", () => {
-      expect(formatPrice(1.0 as USD<number>)).toEqual("$1.00");
+      expect(formatPrice(1.0 as USD<number>)).toEqual("$1");
       expect(formatPrice(1.23 as USD<number>)).toEqual("$1.23");
     });
   });
@@ -357,12 +357,12 @@ describe("formatPrice", () => {
   describe("0.000001 <= x < 1", () => {
     test("from string", () => {
       expect(formatPrice("0.000001" as USD)).toEqual("$0.000001");
-      expect(formatPrice("0.123" as USD)).toEqual("$0.123000");
+      expect(formatPrice("0.123" as USD)).toEqual("$0.123");
       expect(formatPrice("0.123456789" as USD)).toEqual("$0.123456");
     });
     test("from number", () => {
       expect(formatPrice(0.000001 as USD<number>)).toEqual("$0.000001");
-      expect(formatPrice(0.123 as USD<number>)).toEqual("$0.123000");
+      expect(formatPrice(0.123 as USD<number>)).toEqual("$0.123");
       expect(formatPrice(0.123456789 as USD<number>)).toEqual("$0.123456");
     });
   });

--- a/src/lib/utils/formatter/token.ts
+++ b/src/lib/utils/formatter/token.ts
@@ -29,7 +29,7 @@ export const formatDecimal =
           .split(".")[0]
       )
         .div(10 ** decimalPoints)
-        .toFixed(decimalPoints);
+        .toString();
 
       const [i, d] = num.split(".");
       const thousands = /\B(?=(\d{3})+(?!\d))/g;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Removed unnecessary trailing zeros from decimals across the app; integers now display without decimal parts.
  - Normalized “-0” to “0” in all number formats.
  - Token values and token lists display as integers when applicable; list punctuation and thousands separators are preserved.
  - Price formatting is cleaner (e.g., $1 instead of $1.00; precise decimals retained when needed).

- **Chores**
  - Changelog updated with the trailing-zeros bug fix entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->