### PR TITLE
fix: enhance MsgExecute handling in ResendButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
-- [#1441](https://github.com/alleslabs/celatone-frontend/pull/1441) Fix MsgExecute when resend
+- [#1441](https://github.com/alleslabs/celatone-frontend/pull/1441) Fix MsgExecute when resending
 - [#1440](https://github.com/alleslabs/celatone-frontend/pull/1440) Fix decimal points trailing zeros issue
 - [#1439](https://github.com/alleslabs/celatone-frontend/pull/1439) Fix dex pool zod validation
 - [#1438](https://github.com/alleslabs/celatone-frontend/pull/1438) Fix resend button component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+- [#1441](https://github.com/alleslabs/celatone-frontend/pull/1441) Fix MsgExecute when resend
 - [#1440](https://github.com/alleslabs/celatone-frontend/pull/1440) Fix decimal points trailing zeros issue
 - [#1439](https://github.com/alleslabs/celatone-frontend/pull/1439) Fix dex pool zod validation
 - [#1438](https://github.com/alleslabs/celatone-frontend/pull/1438) Fix resend button component

--- a/src/lib/components/button/ResendButton.tsx
+++ b/src/lib/components/button/ResendButton.tsx
@@ -2,6 +2,7 @@ import type { EncodeObject } from "@cosmjs/proto-signing";
 import type { Gas, Message, Msg, Option } from "lib/types";
 
 import { Button } from "@chakra-ui/react";
+import { MsgExecute } from "@initia/initia.js";
 import { AmpEvent, track } from "lib/amplitude";
 import { useFabricateFee, useResendTx } from "lib/app-provider";
 import { useTxBroadcast } from "lib/hooks";
@@ -19,6 +20,17 @@ const formatMsgs = (messages: Message[]) =>
   messages.reduce((acc: EncodeObject[], msg: Message) => {
     // TODO: revisit if detail is undefined
     const detail = msg.detail as Msg;
+    // TODO: workaround for msg move execute
+    if (msg.type === "/initia.move.v1.MsgExecute") {
+      const executeMsg = MsgExecute.fromData(
+        camelToSnake(detail) as unknown as MsgExecute.Data
+      );
+      acc.push({
+        typeUrl: msg.type,
+        value: executeMsg.toProto(),
+      });
+      return acc;
+    }
     acc.push({
       typeUrl: msg.type,
       value: !detail.msg


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where resending transactions containing Move execute messages could fail. These transactions are now properly handled by the Resend flow and can be resent reliably, improving compatibility with Initia Move transactions. Users who previously encountered resend errors for these messages should now see successful submissions.

* **Documentation**
  * Updated the Unreleased Bug Fixes section of the changelog to include this fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->