### PR TITLE
chore: upgrade @initia/tx-decoder to 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+## v1.17.1
+
+### Improvements
+
+- [#1519](https://github.com/alleslabs/celatone-frontend/pull/1519) Upgrade `@initia/tx-decoder` to 0.13.0
+
 ## v1.17.0
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@initia/initia.proto": "1.0.0",
     "@initia/interwovenkit-react": "2.4.0",
     "@initia/react-app-shell": "1.3.1",
-    "@initia/tx-decoder": "0.11.1",
+    "@initia/tx-decoder": "0.13.0",
     "@initia/utils": "2.0.0",
     "@interchain-ui/react": "1.23.9",
     "@lukemorales/query-key-factory": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "celatone",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "author": "Alles Labs",
   "contributors": [
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,8 +133,8 @@ importers:
         specifier: 1.3.1
         version: 1.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@initia/tx-decoder':
-        specifier: 0.11.1
-        version: 0.11.1(@mysten/bcs@1.2.0)(bignumber.js@9.1.2)(bufferutil@4.0.9)(typescript@5.3.3)(utf-8-validate@5.0.10)
+        specifier: 0.13.0
+        version: 0.13.0(@mysten/bcs@1.2.0)(bignumber.js@9.1.2)(bufferutil@4.0.9)(typescript@5.3.3)(utf-8-validate@5.0.10)
       '@initia/utils':
         specifier: 2.0.0
         version: 2.0.0(@cosmjs/encoding@0.36.0)(@mysten/bcs@1.2.0)(@noble/hashes@1.8.0)(bignumber.js@9.1.2)(ky@1.8.0)(viem@2.37.2(bufferutil@4.0.9)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2))
@@ -2656,8 +2656,8 @@ packages:
       react: ^19.0.0
       react-dom: ^19.0.0
 
-  '@initia/tx-decoder@0.11.1':
-    resolution: {integrity: sha512-j2MgAVRLZcjBJEVoqzMS6CIm1lJTHKFH1OM0GANl+4nGErYtjh91f1r7UO8deEDN7QfdjsqI4QzGgQy4jv0z0g==}
+  '@initia/tx-decoder@0.13.0':
+    resolution: {integrity: sha512-BnXQMKPp3Q6JvdDDQJEkXj7Qy+KBp6ZRmopvbDHDA8KpgOsOs6kSzwIyulp/wC6kJ+Q0uhxbQslzd25xgDClRw==}
     engines: {node: '>=24.0.0'}
 
   '@initia/utils@2.0.0':
@@ -15730,7 +15730,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@initia/tx-decoder@0.11.1(@mysten/bcs@1.2.0)(bignumber.js@9.1.2)(bufferutil@4.0.9)(typescript@5.3.3)(utf-8-validate@5.0.10)':
+  '@initia/tx-decoder@0.13.0(@mysten/bcs@1.2.0)(bignumber.js@9.1.2)(bufferutil@4.0.9)(typescript@5.3.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@cosmjs/encoding': 0.36.0
       '@initia/utils': 2.0.0-alpha.3(@cosmjs/encoding@0.36.0)(@mysten/bcs@1.2.0)(@noble/hashes@1.8.0)(bignumber.js@9.1.2)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.25.67))


### PR DESCRIPTION
## Summary
- Upgrade `@initia/tx-decoder` from 0.11.1 to 0.13.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency/version bump only; risk is limited to potential tx-decoder behavior/regression changes at runtime.
> 
> **Overview**
> Updates dependency versions to ship a `v1.17.1` release centered on upgrading `@initia/tx-decoder` from `0.11.1` to `0.13.0`.
> 
> This bumps the app version in `package.json`, refreshes `pnpm-lock.yaml` to the new `@initia/tx-decoder` resolution, and adds a `CHANGELOG.md` entry documenting the upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77c845a86c090796f7600915c05053f6a4f1a729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to the latest compatible versions for improved stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->