### PR TITLE
fix: preserve hex wallet leading nibble and trim Scan search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+- [#1521](https://github.com/alleslabs/celatone-frontend/pull/1521) Preserve leading nibble of 20-byte hex wallet addresses on Move chains so they round-trip with EVM tooling, trim leading and trailing spaces in Scan search
+
 ## v1.17.1
 
 ### Improvements

--- a/src/lib/layout/search/index.tsx
+++ b/src/lib/layout/search/index.tsx
@@ -272,7 +272,7 @@ export const SearchComponent = () => {
             minH={{ base: "80vh", md: "460px" }}
             px={3}
           >
-            {keyword.length > 0 ? (
+            {trimmedKeyword.length > 0 ? (
               <>
                 {isLoading || isTyping ? (
                   <Flex

--- a/src/lib/layout/search/index.tsx
+++ b/src/lib/layout/search/index.tsx
@@ -93,7 +93,9 @@ export const SearchComponent = () => {
     };
   }, [isMac, isOpen, onCloseWithClear, onOpen]);
 
-  const { isLoading, results } = useSearchHandler(keyword, () =>
+  const trimmedKeyword = keyword.trim();
+
+  const { isLoading, results } = useSearchHandler(trimmedKeyword, () =>
     setIsTyping(false)
   );
 
@@ -111,7 +113,7 @@ export const SearchComponent = () => {
           return splitModulePath(result.value) as [Addr, string];
         if (result?.type === "NFT address")
           return [result.metadata?.nft?.collectionAddress ?? "", result.value];
-        return result?.value || keyword;
+        return result?.value || trimmedKeyword;
       };
 
       trackUseMainSearch(isClick, result?.type);
@@ -125,7 +127,7 @@ export const SearchComponent = () => {
         onCloseWithClear();
       }
     },
-    [isEvm, keyword, navigate, onCloseWithClear]
+    [isEvm, trimmedKeyword, navigate, onCloseWithClear]
   );
 
   const handleOnKeyDown = useCallback(

--- a/src/lib/utils/address.test.ts
+++ b/src/lib/utils/address.test.ts
@@ -80,6 +80,14 @@ describe("unpadHexAddress", () => {
     expect(unpadHexAddress(zHexAddr.parse(padded))).toEqual("0x403");
   });
 
+  test("preserves 32-byte module address with meaningful leading zeros", () => {
+    const moduleAddress =
+      "0x0004733bdabcf7d4afc3d14f0dd46c9bf52fb0fce9e4b996c939e195b8bc891d9";
+    expect(unpadHexAddress(zHexAddr.parse(moduleAddress))).toEqual(
+      moduleAddress
+    );
+  });
+
   test("collapses all-zero address to 0x0", () => {
     const padded =
       "0x0000000000000000000000000000000000000000000000000000000000000000";

--- a/src/lib/utils/address.test.ts
+++ b/src/lib/utils/address.test.ts
@@ -1,6 +1,6 @@
-import { zHexAddr20 } from "lib/types";
+import { zHexAddr, zHexAddr20 } from "lib/types";
 
-import { toChecksumAddress } from "./address";
+import { toChecksumAddress, unpadHexAddress } from "./address";
 
 describe("toChecksumAddress", () => {
   test("valid case 1", () => {
@@ -31,5 +31,63 @@ describe("toChecksumAddress", () => {
     const expected = "0x19b95Ef8a6B4C4CcbdEaa76Fe03eB86C89b6AB6C";
     const result = toChecksumAddress(zHexAddr20.parse(expected.toLowerCase()));
     expect(result).toEqual(expected);
+  });
+});
+
+describe("unpadHexAddress", () => {
+  test("preserves leading zero nibble in 20-byte wallet with non-zero first byte", () => {
+    const wallet = "0x0c4b28c50a786ae5501662f4443e8724a0b6fe99";
+    expect(unpadHexAddress(zHexAddr.parse(wallet))).toEqual(wallet);
+  });
+
+  test("preserves leading zero byte in 20-byte wallet address", () => {
+    const wallet = "0x00ab28c50a786ae5501662f4443e8724a0b6fe99";
+    expect(unpadHexAddress(zHexAddr.parse(wallet))).toEqual(wallet);
+  });
+
+  test.each(["0x1", "0x2", "0x3", "0x5", "0x6", "0x8", "0xc", "0xcc"])(
+    "collapses padded short Move address %s to short form",
+    (address) => {
+      const padded = `0x${address.slice(2).padStart(40, "0")}`;
+      expect(unpadHexAddress(zHexAddr.parse(padded))).toEqual(address);
+    }
+  );
+
+  test("collapses padded 20-byte reserved Move address to short form", () => {
+    const padded = "0x0000000000000000000000000000000000000403";
+    expect(unpadHexAddress(zHexAddr.parse(padded))).toEqual("0x403");
+  });
+
+  test("collapses padded short wallet-length Move address to short form", () => {
+    const padded = "0x00000000000000000001";
+    expect(unpadHexAddress(zHexAddr.parse(padded))).toEqual("0x1");
+  });
+
+  test("collapses all-zero 20-byte address to 0x0", () => {
+    const padded = "0x0000000000000000000000000000000000000000";
+    expect(unpadHexAddress(zHexAddr.parse(padded))).toEqual("0x0");
+  });
+
+  test("collapses 32-byte padded module address to short form", () => {
+    const padded =
+      "0x0000000000000000000000000000000000000000000000000000000000000001";
+    expect(unpadHexAddress(zHexAddr.parse(padded))).toEqual("0x1");
+  });
+
+  test("collapses multi-nibble 32-byte Move address to short form", () => {
+    const padded =
+      "0x0000000000000000000000000000000000000000000000000000000000000403";
+    expect(unpadHexAddress(zHexAddr.parse(padded))).toEqual("0x403");
+  });
+
+  test("collapses all-zero address to 0x0", () => {
+    const padded =
+      "0x0000000000000000000000000000000000000000000000000000000000000000";
+    expect(unpadHexAddress(zHexAddr.parse(padded))).toEqual("0x0");
+  });
+
+  test("passes already-short forms through unchanged", () => {
+    const named = "0x1";
+    expect(unpadHexAddress(zHexAddr.parse(named))).toEqual(named);
   });
 });

--- a/src/lib/utils/address.test.ts
+++ b/src/lib/utils/address.test.ts
@@ -82,7 +82,7 @@ describe("unpadHexAddress", () => {
 
   test("preserves 32-byte module address with meaningful leading zeros", () => {
     const moduleAddress =
-      "0x0004733bdabcf7d4afc3d14f0dd46c9bf52fb0fce9e4b996c939e195b8bc891d9";
+      "0x0004733bdabcf7d4afc3d14f0dd46c9bf52fb0fce9e4b996c939e195b8bc891d";
     expect(unpadHexAddress(zHexAddr.parse(moduleAddress))).toEqual(
       moduleAddress
     );

--- a/src/lib/utils/address.ts
+++ b/src/lib/utils/address.ts
@@ -9,7 +9,6 @@ import {
   toBech32,
   toHex,
 } from "@cosmjs/encoding";
-import { HEX_MODULE_ADDRESS_LENGTH } from "lib/data";
 import { zBechAddr20, zHexAddr } from "lib/types";
 
 import { utf8ToBytes } from "./base64";
@@ -46,10 +45,7 @@ const removeLeadingZeros = (hex: string) => hex.replace(/^0+/, "") || "0";
 const isPaddedMoveAddress = (hex: string) => {
   const unpadded = removeLeadingZeros(hex);
 
-  return (
-    hex.length === HEX_MODULE_ADDRESS_LENGTH ||
-    (hex.length > unpadded.length && unpadded.length <= 3)
-  );
+  return hex.length > unpadded.length && unpadded.length <= 3;
 };
 
 export const unpadHexAddress = (hexAddr: HexAddr) => {

--- a/src/lib/utils/address.ts
+++ b/src/lib/utils/address.ts
@@ -9,6 +9,7 @@ import {
   toBech32,
   toHex,
 } from "@cosmjs/encoding";
+import { HEX_MODULE_ADDRESS_LENGTH } from "lib/data";
 import { zBechAddr20, zHexAddr } from "lib/types";
 
 import { utf8ToBytes } from "./base64";
@@ -40,8 +41,24 @@ export const bech32AddressToHex = (addr: BechAddr): HexAddr =>
 export const padHexAddress = (hexAddr: HexAddr, length: number): HexAddr =>
   zHexAddr.parse(`0x${hexAddr.slice(2).padStart(length, "0")}`);
 
-export const unpadHexAddress = (hexAddr: HexAddr) =>
-  zHexAddr.parse(`0x${hexAddr.slice(2).replace(/^0+/, "")}`);
+const removeLeadingZeros = (hex: string) => hex.replace(/^0+/, "") || "0";
+
+const isPaddedMoveAddress = (hex: string) => {
+  const unpadded = removeLeadingZeros(hex);
+
+  return (
+    hex.length === HEX_MODULE_ADDRESS_LENGTH ||
+    (hex.length > unpadded.length && unpadded.length <= 3)
+  );
+};
+
+export const unpadHexAddress = (hexAddr: HexAddr) => {
+  const stripped = hexAddr.slice(2);
+
+  return isPaddedMoveAddress(stripped)
+    ? zHexAddr.parse(`0x${removeLeadingZeros(stripped)}`)
+    : hexAddr;
+};
 
 export const hexToBech32Address = (
   prefix: string,


### PR DESCRIPTION
## Summary
- Preserve leading nibble of 20-byte hex wallet addresses; only collapse padded Move-style addresses in `unpadHexAddress`
- Trim leading/trailing spaces from Scan search keyword before lookup and navigation
- Add unit coverage for `unpadHexAddress` wallet preservation and Move-address collapse

Fixes QA-1547
Fixes QA-1556

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f86b1affe7e591434e4303748d8cd0fa38366678. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Move-chain 20-byte wallet addresses now round-trip with correct formatting, preserving leading nibble so addresses display and copy back consistently.
  * Search/Scan input now trims leading and trailing spaces automatically, improving search results and reducing accidental no-results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->