### PR TITLE
feat: fetch tx details from indexer on sequencer tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
+- [#1525](https://github.com/alleslabs/celatone-frontend/pull/1525) Fetch tx details from indexer on sequencer tier
+
 ### Bug fixes
 
 - [#1521](https://github.com/alleslabs/celatone-frontend/pull/1521) Preserve leading nibble of 20-byte hex wallet addresses on Move chains so they round-trip with EVM tooling, trim leading and trailing spaces in Scan search

--- a/src/lib/services/tx/index.ts
+++ b/src/lib/services/tx/index.ts
@@ -76,6 +76,7 @@ import {
   getTxsByHashRest,
 } from "./rest";
 import {
+  getTxDataSequencer,
   getTxsByAccountAddressSequencer,
   getTxsByBlockHeightSequencer,
   getTxsByHashSequencer,
@@ -133,16 +134,20 @@ export const useTxData = (
 ): UseQueryResult<TxData> => {
   const { bech32Prefix } = useCurrentChain();
   const {
-    chainConfig: { rest: restEndpoint },
+    chainConfig: { indexer: indexerEndpoint, rest: restEndpoint },
     currentChainId,
   } = useCelatoneApp();
-  const { isFullTier } = useTierConfig();
+  const { isFullTier, isSequencerTier } = useTierConfig();
   const apiEndpoint = useBaseApiRoute("txs");
   const { txDecoder } = useTxDecoderContext();
   const evm = useEvmConfig({ shouldRedirect: false });
   const wasm = useWasmConfig({ shouldRedirect: false });
 
-  const endpoint = isFullTier ? apiEndpoint : restEndpoint;
+  const endpoint = isFullTier
+    ? apiEndpoint
+    : isSequencerTier
+      ? indexerEndpoint
+      : restEndpoint;
 
   const queryFn = useCallback(
     async (hash: Option<string>) => {
@@ -150,7 +155,9 @@ export const useTxData = (
 
       const txData = isFullTier
         ? await getTxData(endpoint, hash)
-        : await getTxDataRest(endpoint, hash);
+        : isSequencerTier
+          ? await getTxDataSequencer(endpoint, hash)
+          : await getTxDataRest(endpoint, hash);
 
       const { rawTxResponse, txResponse } = txData;
 
@@ -183,6 +190,7 @@ export const useTxData = (
       currentChainId,
       endpoint,
       isFullTier,
+      isSequencerTier,
       txDecoder,
       evm.enabled,
       wasm.enabled,

--- a/src/lib/services/tx/sequencer.ts
+++ b/src/lib/services/tx/sequencer.ts
@@ -7,10 +7,20 @@ import type { TxsResponseItemFromRest } from "../types";
 
 import {
   zBlockTxsResponseSequencer,
+  zTxByHashResponseSequencer,
   zTxsByHashResponseSequencer,
   zTxsResponseSequencer,
 } from "../types";
 import { queryWithArchivalFallback } from "../utils";
+
+export const getTxDataSequencer = (endpoint: string, txHash: string) => {
+  const fetch = (endpoint: string) =>
+    axios
+      .get(`${endpoint}/indexer/tx/v1/txs/${encodeURI(txHash)}`)
+      .then(({ data }) => parseWithError(zTxByHashResponseSequencer, data));
+
+  return queryWithArchivalFallback(endpoint, fetch);
+};
 
 // NOTE: Replace with new txs count endpoint
 export const getTxsCountSequencer = (endpoint: string) =>

--- a/src/lib/services/types/tx.ts
+++ b/src/lib/services/types/tx.ts
@@ -371,6 +371,25 @@ export const zTxByHashResponseRest = z.preprocess(
     }))
 );
 
+export const zTxByHashResponseSequencer = z.preprocess(
+  (arg: unknown) => {
+    const val = arg as Record<string, unknown>;
+    return {
+      raw_tx_response: val.tx,
+      tx_response: val.tx,
+    };
+  },
+  z
+    .object({
+      raw_tx_response: z.any(),
+      tx_response: zTxResponse.transform(snakeToCamel),
+    })
+    .transform((val) => ({
+      rawTxResponse: val.raw_tx_response,
+      txResponse: val.tx_response,
+    }))
+);
+
 const zBaseTxsResponseItem = z.preprocess(
   (arg: unknown) => {
     const val = arg as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Add `getTxDataSequencer` hitting `/indexer/tx/v1/txs/{hash}`
- Add `zTxByHashResponseSequencer` matching the sequencer response shape
- Branch `useTxData` to use the indexer endpoint when tier is sequencer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how transaction details are fetched for sequencer-tier networks by routing through the indexer endpoint, which could impact tx detail reliability/shape if the indexer response differs or is unavailable.
> 
> **Overview**
> Transaction details fetching is updated to **use the indexer on sequencer-tier networks** instead of falling back to the REST endpoint.
> 
> This adds `getTxDataSequencer` (calling `GET /indexer/tx/v1/txs/{hash}` with archival fallback) plus a new Zod parser `zTxByHashResponseSequencer` to adapt the indexer response into the existing `TxData` shape, and wires `useTxData` to select the correct endpoint/function based on tier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a42f07dbde3681f5bd6c1ca744d92f6d2822fa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->