### PR TITLE
chore: develop to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
+- [#1525](https://github.com/alleslabs/celatone-frontend/pull/1525) Fetch tx details from indexer on sequencer tier
+
 ### Bug fixes
 
 - [#1521](https://github.com/alleslabs/celatone-frontend/pull/1521) Preserve leading nibble of 20-byte hex wallet addresses on Move chains so they round-trip with EVM tooling, trim leading and trailing spaces in Scan search

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
+### Bug fixes
+
+## v1.18.0
+
+### Improvements
+
 - [#1525](https://github.com/alleslabs/celatone-frontend/pull/1525) Fetch tx details from indexer on sequencer tier
 
 ### Bug fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "celatone",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "author": "Alles Labs",
   "contributors": [
     {

--- a/src/lib/services/tx/index.ts
+++ b/src/lib/services/tx/index.ts
@@ -76,6 +76,7 @@ import {
   getTxsByHashRest,
 } from "./rest";
 import {
+  getTxDataSequencer,
   getTxsByAccountAddressSequencer,
   getTxsByBlockHeightSequencer,
   getTxsByHashSequencer,
@@ -133,16 +134,20 @@ export const useTxData = (
 ): UseQueryResult<TxData> => {
   const { bech32Prefix } = useCurrentChain();
   const {
-    chainConfig: { rest: restEndpoint },
+    chainConfig: { indexer: indexerEndpoint, rest: restEndpoint },
     currentChainId,
   } = useCelatoneApp();
-  const { isFullTier } = useTierConfig();
+  const { isFullTier, isSequencerTier } = useTierConfig();
   const apiEndpoint = useBaseApiRoute("txs");
   const { txDecoder } = useTxDecoderContext();
   const evm = useEvmConfig({ shouldRedirect: false });
   const wasm = useWasmConfig({ shouldRedirect: false });
 
-  const endpoint = isFullTier ? apiEndpoint : restEndpoint;
+  const endpoint = isFullTier
+    ? apiEndpoint
+    : isSequencerTier
+      ? indexerEndpoint
+      : restEndpoint;
 
   const queryFn = useCallback(
     async (hash: Option<string>) => {
@@ -150,7 +155,9 @@ export const useTxData = (
 
       const txData = isFullTier
         ? await getTxData(endpoint, hash)
-        : await getTxDataRest(endpoint, hash);
+        : isSequencerTier
+          ? await getTxDataSequencer(endpoint, hash)
+          : await getTxDataRest(endpoint, hash);
 
       const { rawTxResponse, txResponse } = txData;
 
@@ -183,6 +190,7 @@ export const useTxData = (
       currentChainId,
       endpoint,
       isFullTier,
+      isSequencerTier,
       txDecoder,
       evm.enabled,
       wasm.enabled,

--- a/src/lib/services/tx/sequencer.ts
+++ b/src/lib/services/tx/sequencer.ts
@@ -7,10 +7,20 @@ import type { TxsResponseItemFromRest } from "../types";
 
 import {
   zBlockTxsResponseSequencer,
+  zTxByHashResponseSequencer,
   zTxsByHashResponseSequencer,
   zTxsResponseSequencer,
 } from "../types";
 import { queryWithArchivalFallback } from "../utils";
+
+export const getTxDataSequencer = (endpoint: string, txHash: string) => {
+  const fetch = (endpoint: string) =>
+    axios
+      .get(`${endpoint}/indexer/tx/v1/txs/${encodeURI(txHash)}`)
+      .then(({ data }) => parseWithError(zTxByHashResponseSequencer, data));
+
+  return queryWithArchivalFallback(endpoint, fetch);
+};
 
 // NOTE: Replace with new txs count endpoint
 export const getTxsCountSequencer = (endpoint: string) =>

--- a/src/lib/services/types/tx.ts
+++ b/src/lib/services/types/tx.ts
@@ -371,6 +371,25 @@ export const zTxByHashResponseRest = z.preprocess(
     }))
 );
 
+export const zTxByHashResponseSequencer = z.preprocess(
+  (arg: unknown) => {
+    const val = arg as Record<string, unknown>;
+    return {
+      raw_tx_response: val.tx,
+      tx_response: val.tx,
+    };
+  },
+  z
+    .object({
+      raw_tx_response: z.any(),
+      tx_response: zTxResponse.transform(snakeToCamel),
+    })
+    .transform((val) => ({
+      rawTxResponse: val.raw_tx_response,
+      txResponse: val.tx_response,
+    }))
+);
+
 const zBaseTxsResponseItem = z.preprocess(
   (arg: unknown) => {
     const val = arg as Record<string, unknown>;


### PR DESCRIPTION
## Summary
Promote develop to main.

Includes:
- #1525 feat: fetch tx details from indexer on sequencer tier
- #1524 chore: upgrade @initia/tx-decoder to 0.13.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the transaction details fetch path on sequencer tier to use an indexer endpoint and new response parsing, which could impact tx detail rendering if the indexer schema differs or is misconfigured.
> 
> **Overview**
> Transaction detail fetching is updated so **sequencer tier** now retrieves per-hash tx details from the **indexer** (via a new `getTxDataSequencer`) instead of falling back to the REST endpoint.
> 
> This adds a new Zod parser (`zTxByHashResponseSequencer`) to normalize the indexer’s single-tx response into the existing `{ rawTxResponse, txResponse }` shape, and wires the new `isSequencerTier` branching into `useTxData` endpoint selection.
> 
> Bumps the release to `v1.18.0` in `package.json` and records the release entry in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d049b3b31cf85c555f216b192d8b26522ee31571. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->