### PR TITLE
fix(types): accept nullable response logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+- [#1529](https://github.com/alleslabs/celatone-frontend/pull/1529) Fix account transaction pagination when historical responses contain null logs
+
 ## v1.18.0
 
 ### Improvements

--- a/src/lib/services/types/tx.ts
+++ b/src/lib/services/types/tx.ts
@@ -205,7 +205,10 @@ const zRawTxResponse = z.preprocess(
     gas_wanted: z.string(),
     height: z.string(),
     info: z.string(),
-    logs: z.array(zLog),
+    logs: z
+      .array(zLog)
+      .nullable()
+      .transform((val) => val ?? []),
     raw_log: z.string(),
     timestamp: z.string(),
     tx: zTx,


### PR DESCRIPTION
## Summary

- normalize historical transaction responses with null logs to an empty array
- restore pagination for affected historical transaction pages

## Testing

- pnpm exec jest src/lib/utils/tx/__test__/extractTxLogs.test.ts --runInBand --coverage=false
- pnpm type-check
- pnpm exec eslint src/lib/services/types/tx.ts
- verified pages 21 and 24 locally against the live API

Fixes QA-1599