### PR TITLE
fix: support recoverable swap display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
+- Upgrade `@initia/tx-decoder` to 0.14.0 to support pretty display for `swap_and_action_with_recover` transactions (EXP-1051)
+
 ### Bug fixes
 
 ## v1.18.0

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@initia/initia.proto": "1.0.0",
     "@initia/interwovenkit-react": "2.4.0",
     "@initia/react-app-shell": "1.3.1",
-    "@initia/tx-decoder": "0.13.2",
+    "@initia/tx-decoder": "0.14.0",
     "@initia/utils": "2.0.0",
     "@interchain-ui/react": "1.23.9",
     "@lukemorales/query-key-factory": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,8 +133,8 @@ importers:
         specifier: 1.3.1
         version: 1.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@initia/tx-decoder':
-        specifier: 0.13.2
-        version: 0.13.2(@mysten/bcs@1.2.0)(bignumber.js@9.1.2)(bufferutil@4.0.9)(typescript@5.3.3)(utf-8-validate@5.0.10)
+        specifier: 0.14.0
+        version: 0.14.0(@mysten/bcs@1.2.0)(bignumber.js@9.1.2)(bufferutil@4.0.9)(typescript@5.3.3)(utf-8-validate@5.0.10)
       '@initia/utils':
         specifier: 2.0.0
         version: 2.0.0(@cosmjs/encoding@0.36.0)(@mysten/bcs@1.2.0)(@noble/hashes@1.8.0)(bignumber.js@9.1.2)(ky@1.8.0)(viem@2.37.2(bufferutil@4.0.9)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2))
@@ -2656,8 +2656,8 @@ packages:
       react: ^19.0.0
       react-dom: ^19.0.0
 
-  '@initia/tx-decoder@0.13.2':
-    resolution: {integrity: sha512-J53NcSKwJBBaIIIe3cYAUkEm66A78RiWby1NV4MF+K0bpNl2JYH7BQ6orS8p40V2qqkgurm+SAEGQgTE3co6Hw==}
+  '@initia/tx-decoder@0.14.0':
+    resolution: {integrity: sha512-GS4wPVoczdM7Lzk8S8qgO+9AeumWuM8K00yEx6Hg3RcywPSyy4EzkqWB9jj8ra1HYQSi/ZO2j0gd/6epBnPKyg==}
     engines: {node: '>=24.0.0'}
 
   '@initia/utils@2.0.0':
@@ -15730,7 +15730,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@initia/tx-decoder@0.13.2(@mysten/bcs@1.2.0)(bignumber.js@9.1.2)(bufferutil@4.0.9)(typescript@5.3.3)(utf-8-validate@5.0.10)':
+  '@initia/tx-decoder@0.14.0(@mysten/bcs@1.2.0)(bignumber.js@9.1.2)(bufferutil@4.0.9)(typescript@5.3.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@cosmjs/encoding': 0.36.0
       '@initia/utils': 2.0.0-alpha.3(@cosmjs/encoding@0.36.0)(@mysten/bcs@1.2.0)(@noble/hashes@1.8.0)(bignumber.js@9.1.2)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.25.67))


### PR DESCRIPTION
## Summary
- upgrade @initia/tx-decoder to 0.14.0
- support pretty Swap rendering for swap_and_action_with_recover
- document EXP-1051 in the changelog

## Verification
- replayed F54F0CBAEFB5509845C482C3D7AF01B2CAEB8AA15B36201A00631405F2DA920D: 500 USDC to 10,185.848708 INIT
- pnpm type-check
- pnpm lint
- pnpm test -- --runInBand
- verified the local transaction page renders the Swap view

Fixes EXP-1051

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump affecting tx message display; no auth, data, or app logic changes in this diff.
> 
> **Overview**
> Bumps **`@initia/tx-decoder`** from **0.13.2** to **0.14.0** (and lockfile) so transaction pages can show the **Swap** UI for **`swap_and_action_with_recover`** messages instead of a generic decode. No application source changes—behavior comes from the library.
> 
> Documents the change under **Unreleased → Improvements** in the changelog (EXP-1051).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 927297866d83d98cb4611348b421ceeb45328c9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved the display of `swap_and_action_with_recover` transactions.
  * Updated the transaction decoder to version 0.14.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->