### PR TITLE
Prevent transaction scans from freezing on repeated loads

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[mcp_servers.linear]
+url = "https://mcp.linear.app/mcp"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,2 +1,0 @@
-[mcp_servers.linear]
-url = "https://mcp.linear.app/mcp"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
-- Prevent the transaction list from freezing when loading more transactions (QA-1600)
+- [#1533](https://github.com/alleslabs/celatone-frontend/pull/1533) Prevent the transaction list from freezing when loading more transactions
 - [#1529](https://github.com/alleslabs/celatone-frontend/pull/1529) Fix account transaction pagination when historical responses contain null logs
 
 ## v1.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+- Prevent the transaction list from freezing when loading more transactions (QA-1600)
 - [#1529](https://github.com/alleslabs/celatone-frontend/pull/1529) Fix account transaction pagination when historical responses contain null logs
 
 ## v1.18.0

--- a/src/lib/components/table/transactions/TransactionsTableMobileCard.tsx
+++ b/src/lib/components/table/transactions/TransactionsTableMobileCard.tsx
@@ -1,11 +1,13 @@
 import type { TransactionWithTxResponse } from "lib/types";
 
-import { Flex, Text } from "@chakra-ui/react";
+import { Box, Flex, Text } from "@chakra-ui/react";
 import { useInternalNavigate } from "lib/app-provider";
 import { ExplorerLink } from "lib/components/ExplorerLink";
 import { CustomIcon } from "lib/components/icon";
 import { useTxDecoder } from "lib/services/tx";
 import { dateFromNow, formatUTC } from "lib/utils";
+import { memo } from "react";
+import { useInView } from "react-intersection-observer";
 
 import { MobileCardTemplate } from "../MobileCardTemplate";
 import { MobileLabel } from "../MobileLabel";
@@ -18,97 +20,121 @@ interface TransactionsTableMobileCardProps {
   showTimestamp: boolean;
   transaction: TransactionWithTxResponse;
 }
-export const TransactionsTableMobileCard = ({
+const TransactionsTableMobileCardComponent = ({
   showRelations,
   showSuccess,
   showTimestamp,
   transaction,
 }: TransactionsTableMobileCardProps) => {
   const navigate = useInternalNavigate();
+  const { inView, ref } = useInView({ triggerOnce: true });
   const isTxHasNoData = transaction.height === 0;
   const { rawTxResponse, txResponse } = transaction;
   const { data: decodedTx, isFetching: isDecodedTxFetching } =
-    useTxDecoder(rawTxResponse);
+    useTxDecoder(rawTxResponse, { defer: true, enabled: inView });
 
   return (
-    <MobileCardTemplate
-      bottomContent={
-        <Flex direction="column" gap={3}>
-          <Flex direction="column">
-            <MobileLabel label="sender" />
-            {isTxHasNoData ? (
-              <Text color="gray.600" variant="body2">
-                N/A
-              </Text>
-            ) : (
+    <Box
+      style={{
+        containIntrinsicSize: "auto 160px",
+        contentVisibility: "auto",
+      }}
+      w="full"
+      ref={ref}
+    >
+      <MobileCardTemplate
+        bottomContent={
+          <Flex direction="column" gap={3}>
+            <Flex direction="column">
+              <MobileLabel label="sender" />
+              {isTxHasNoData ? (
+                <Text color="gray.600" variant="body2">
+                  N/A
+                </Text>
+              ) : (
+                <ExplorerLink
+                  showCopyOnHover
+                  type="user_address"
+                  value={transaction.sender}
+                />
+              )}
+            </Flex>
+            {showTimestamp && !isTxHasNoData && (
+              <Flex direction="column">
+                <Text variant="body3">{formatUTC(transaction.created)}</Text>
+                <Text color="text.dark" variant="body3">
+                  {`(${dateFromNow(transaction.created)})`}
+                </Text>
+              </Flex>
+            )}
+          </Flex>
+        }
+        middleContent={
+          isTxHasNoData ? (
+            <Text color="gray.600" variant="body2">
+              Unable to load data due to large transaction size
+            </Text>
+          ) : (
+            <TransactionsTableDecodeMessageColumn
+              decodedTx={decodedTx}
+              isDecodedTxFetching={isDecodedTxFetching}
+              transaction={transaction}
+              txResponse={txResponse}
+            />
+          )
+        }
+        topContent={
+          <>
+            <Flex align="center" gap={2}>
+              {showSuccess && !isTxHasNoData && (
+                <>
+                  {transaction.success ? (
+                    <CustomIcon
+                      boxSize={3}
+                      color="success.main"
+                      name="check-circle-solid"
+                    />
+                  ) : (
+                    <CustomIcon
+                      boxSize={3}
+                      color="error.main"
+                      name="close-circle-solid"
+                    />
+                  )}
+                </>
+              )}
               <ExplorerLink
                 showCopyOnHover
-                type="user_address"
-                value={transaction.sender}
+                type="tx_hash"
+                value={transaction.hash.toLocaleUpperCase()}
               />
-            )}
-          </Flex>
-          {showTimestamp && !isTxHasNoData && (
-            <Flex direction="column">
-              <Text variant="body3">{formatUTC(transaction.created)}</Text>
-              <Text color="text.dark" variant="body3">
-                {`(${dateFromNow(transaction.created)})`}
-              </Text>
             </Flex>
-          )}
-        </Flex>
-      }
-      middleContent={
-        isTxHasNoData ? (
-          <Text color="gray.600" variant="body2">
-            Unable to load data due to large transaction size
-          </Text>
-        ) : (
-          <TransactionsTableDecodeMessageColumn
-            decodedTx={decodedTx}
-            isDecodedTxFetching={isDecodedTxFetching}
-            transaction={transaction}
-            txResponse={txResponse}
-          />
-        )
-      }
-      topContent={
-        <>
-          <Flex align="center" gap={2}>
-            {showSuccess && !isTxHasNoData && (
-              <>
-                {transaction.success ? (
-                  <CustomIcon
-                    boxSize={3}
-                    color="success.main"
-                    name="check-circle-solid"
-                  />
-                ) : (
-                  <CustomIcon
-                    boxSize={3}
-                    color="error.main"
-                    name="close-circle-solid"
-                  />
-                )}
-              </>
+            {showRelations && !isTxHasNoData && (
+              <RelationChip isSigner={transaction.isSigner} />
             )}
-            <ExplorerLink
-              showCopyOnHover
-              type="tx_hash"
-              value={transaction.hash.toLocaleUpperCase()}
-            />
-          </Flex>
-          {showRelations && !isTxHasNoData && (
-            <RelationChip isSigner={transaction.isSigner} />
-          )}
-        </>
-      }
-      onClick={() =>
-        navigate({
-          pathname: "/txs/[txHash]",
-          query: { txHash: transaction.hash.toLocaleUpperCase() },
-        })
-      }
-    />
+          </>
+        }
+        onClick={() =>
+          navigate({
+            pathname: "/txs/[txHash]",
+            query: { txHash: transaction.hash.toLocaleUpperCase() },
+          })
+        }
+      />
+    </Box>
   );
 };
+
+const isSameTransactionMobileCard = (
+  previous: TransactionsTableMobileCardProps,
+  next: TransactionsTableMobileCardProps
+) =>
+  previous.transaction.hash === next.transaction.hash &&
+  previous.showRelations === next.showRelations &&
+  previous.showSuccess === next.showSuccess &&
+  previous.showTimestamp === next.showTimestamp;
+
+export const TransactionsTableMobileCard = memo(
+  TransactionsTableMobileCardComponent,
+  isSameTransactionMobileCard
+);

--- a/src/lib/components/table/transactions/TransactionsTableMobileCard.tsx
+++ b/src/lib/components/table/transactions/TransactionsTableMobileCard.tsx
@@ -30,8 +30,10 @@ const TransactionsTableMobileCardComponent = ({
   const { inView, ref } = useInView({ triggerOnce: true });
   const isTxHasNoData = transaction.height === 0;
   const { rawTxResponse, txResponse } = transaction;
-  const { data: decodedTx, isFetching: isDecodedTxFetching } =
-    useTxDecoder(rawTxResponse, { defer: true, enabled: inView });
+  const { data: decodedTx, isFetching: isDecodedTxFetching } = useTxDecoder(
+    rawTxResponse,
+    { defer: true, enabled: inView }
+  );
 
   return (
     <Box
@@ -125,16 +127,6 @@ const TransactionsTableMobileCardComponent = ({
   );
 };
 
-const isSameTransactionMobileCard = (
-  previous: TransactionsTableMobileCardProps,
-  next: TransactionsTableMobileCardProps
-) =>
-  previous.transaction.hash === next.transaction.hash &&
-  previous.showRelations === next.showRelations &&
-  previous.showSuccess === next.showSuccess &&
-  previous.showTimestamp === next.showTimestamp;
-
 export const TransactionsTableMobileCard = memo(
-  TransactionsTableMobileCardComponent,
-  isSameTransactionMobileCard
+  TransactionsTableMobileCardComponent
 );

--- a/src/lib/components/table/transactions/TransactionsTableRow.tsx
+++ b/src/lib/components/table/transactions/TransactionsTableRow.tsx
@@ -41,8 +41,10 @@ const TransactionsTableRowComponent = ({
   const isAccordion = transaction.messages.length > 1;
   const isTxHasNoData = transaction.height === 0;
   const { rawTxResponse, txResponse } = transaction;
-  const { data: decodedTx, isFetching: isDecodedTxFetching } =
-    useTxDecoder(rawTxResponse, { defer: true, enabled: inView });
+  const { data: decodedTx, isFetching: isDecodedTxFetching } = useTxDecoder(
+    rawTxResponse,
+    { defer: true, enabled: inView }
+  );
 
   return (
     <Box
@@ -179,18 +181,4 @@ const TransactionsTableRowComponent = ({
   );
 };
 
-const isSameTransactionRow = (
-  previous: TransactionsTableRowProps,
-  next: TransactionsTableRowProps
-) =>
-  previous.transaction.hash === next.transaction.hash &&
-  previous.showAction === next.showAction &&
-  previous.showRelations === next.showRelations &&
-  previous.showSuccess === next.showSuccess &&
-  previous.showTimestamp === next.showTimestamp &&
-  previous.templateColumns === next.templateColumns;
-
-export const TransactionsTableRow = memo(
-  TransactionsTableRowComponent,
-  isSameTransactionRow
-);
+export const TransactionsTableRow = memo(TransactionsTableRowComponent);

--- a/src/lib/components/table/transactions/TransactionsTableRow.tsx
+++ b/src/lib/components/table/transactions/TransactionsTableRow.tsx
@@ -4,6 +4,8 @@ import { CustomIcon } from "lib/components/icon";
 import { useTxDecoder } from "lib/services/tx";
 import { type TransactionWithTxResponse } from "lib/types";
 import { dateFromNow, formatUTC } from "lib/utils";
+import { memo } from "react";
+import { useInView } from "react-intersection-observer";
 
 import { AccordionTx } from "../AccordionTx";
 import { TableNoBorderRow } from "../tableComponents";
@@ -26,7 +28,7 @@ const NARow = () => (
   </TableNoBorderRow>
 );
 
-export const TransactionsTableRow = ({
+const TransactionsTableRowComponent = ({
   showAction,
   showRelations,
   showSuccess,
@@ -35,18 +37,24 @@ export const TransactionsTableRow = ({
   transaction,
 }: TransactionsTableRowProps) => {
   const { isOpen, onToggle } = useDisclosure();
+  const { inView, ref } = useInView({ triggerOnce: true });
   const isAccordion = transaction.messages.length > 1;
   const isTxHasNoData = transaction.height === 0;
   const { rawTxResponse, txResponse } = transaction;
   const { data: decodedTx, isFetching: isDecodedTxFetching } =
-    useTxDecoder(rawTxResponse);
+    useTxDecoder(rawTxResponse, { defer: true, enabled: inView });
 
   return (
     <Box
+      style={{
+        containIntrinsicSize: "auto 72px",
+        contentVisibility: "auto",
+      }}
       borderBottom="1px solid"
       borderColor="gray.700"
       minW="min-content"
       w="full"
+      ref={ref}
     >
       <Grid
         className="copier-wrapper"
@@ -170,3 +178,19 @@ export const TransactionsTableRow = ({
     </Box>
   );
 };
+
+const isSameTransactionRow = (
+  previous: TransactionsTableRowProps,
+  next: TransactionsTableRowProps
+) =>
+  previous.transaction.hash === next.transaction.hash &&
+  previous.showAction === next.showAction &&
+  previous.showRelations === next.showRelations &&
+  previous.showSuccess === next.showSuccess &&
+  previous.showTimestamp === next.showTimestamp &&
+  previous.templateColumns === next.templateColumns;
+
+export const TransactionsTableRow = memo(
+  TransactionsTableRowComponent,
+  isSameTransactionRow
+);

--- a/src/lib/services/tx/index.ts
+++ b/src/lib/services/tx/index.ts
@@ -90,6 +90,8 @@ interface TxDecoderOptions {
   enabled?: boolean;
 }
 
+const TX_DECODER_IDLE_TIMEOUT_MS = 2000;
+
 const waitForBrowserIdle = () =>
   new Promise<void>((resolve) => {
     if (typeof window === "undefined" || !("requestIdleCallback" in window)) {
@@ -97,7 +99,9 @@ const waitForBrowserIdle = () =>
       return;
     }
 
-    window.requestIdleCallback(() => resolve());
+    window.requestIdleCallback(() => resolve(), {
+      timeout: TX_DECODER_IDLE_TIMEOUT_MS,
+    });
   });
 
 export const useTxDecoder = (

--- a/src/lib/services/tx/index.ts
+++ b/src/lib/services/tx/index.ts
@@ -69,6 +69,7 @@ import {
   getTxDataJsonRpc,
   getTxsDataJsonRpc,
 } from "./jsonRpc";
+import { getTxDecoderQueryKey } from "./queryKey";
 import {
   getTxDataRest,
   getTxsByAccountAddressRest,
@@ -84,20 +85,34 @@ import {
   getTxsSequencer,
 } from "./sequencer";
 
-export const useTxDecoder = (rawTxResponse: Option<RawTxResponse>) => {
+interface TxDecoderOptions {
+  defer?: boolean;
+  enabled?: boolean;
+}
+
+const waitForBrowserIdle = () =>
+  new Promise<void>((resolve) => {
+    if (typeof window === "undefined" || !("requestIdleCallback" in window)) {
+      setTimeout(resolve, 0);
+      return;
+    }
+
+    window.requestIdleCallback(() => resolve());
+  });
+
+export const useTxDecoder = (
+  rawTxResponse: Option<RawTxResponse>,
+  { defer = false, enabled = true }: TxDecoderOptions = {}
+) => {
   const evm = useEvmConfig({ shouldRedirect: false });
   const wasm = useWasmConfig({ shouldRedirect: false });
   const { txDecoder } = useTxDecoderContext();
 
   return useQuery({
-    queryKey: [
-      CELATONE_QUERY_KEYS.TX_DECODER,
-      rawTxResponse,
-      evm.enabled,
-      evm.enabled && evm.jsonRpc,
-      wasm.enabled,
-    ],
+    enabled: enabled && !!rawTxResponse,
     queryFn: async () => {
+      if (defer) await waitForBrowserIdle();
+
       if (evm.enabled) {
         return txDecoder.decodeCosmosEvmTransaction(rawTxResponse);
       }
@@ -106,7 +121,14 @@ export const useTxDecoder = (rawTxResponse: Option<RawTxResponse>) => {
       }
       return txDecoder.decodeCosmosTransaction(rawTxResponse);
     },
-    enabled: !!rawTxResponse,
+    queryKey: getTxDecoderQueryKey({
+      defer,
+      evmEnabled: evm.enabled,
+      evmJsonRpc: evm.enabled ? evm.jsonRpc : undefined,
+      rawTxResponse,
+      wasmEnabled: wasm.enabled,
+    }),
+    staleTime: Infinity,
   });
 };
 

--- a/src/lib/services/tx/queryKey.test.ts
+++ b/src/lib/services/tx/queryKey.test.ts
@@ -1,0 +1,35 @@
+import type { RawTxResponse } from "lib/services/types";
+
+import { CELATONE_QUERY_KEYS } from "lib/app-provider/env";
+
+import { getTxDecoderQueryKey } from "./queryKey";
+
+describe("getTxDecoderQueryKey", () => {
+  test("identifies a decoded transaction without hashing its response", () => {
+    const rawTxResponse = {
+      events: Array.from({ length: 100 }, (_, index) => ({
+        attributes: [{ key: "large", value: "payload".repeat(100) }],
+        type: `event-${index}`,
+      })),
+      txhash: "A".repeat(64),
+    } as RawTxResponse;
+
+    const queryKey = getTxDecoderQueryKey({
+      defer: true,
+      evmEnabled: false,
+      evmJsonRpc: undefined,
+      rawTxResponse,
+      wasmEnabled: false,
+    });
+
+    expect(queryKey).toEqual([
+      CELATONE_QUERY_KEYS.TX_DECODER,
+      rawTxResponse.txhash,
+      false,
+      false,
+      false,
+      true,
+    ]);
+    expect(queryKey).not.toContain(rawTxResponse);
+  });
+});

--- a/src/lib/services/tx/queryKey.ts
+++ b/src/lib/services/tx/queryKey.ts
@@ -1,0 +1,28 @@
+import type { RawTxResponse } from "lib/services/types";
+import type { Option } from "lib/types";
+
+import { CELATONE_QUERY_KEYS } from "lib/app-provider/env";
+
+interface TxDecoderQueryKeyOptions {
+  defer: boolean;
+  evmEnabled: boolean;
+  evmJsonRpc: Option<string>;
+  rawTxResponse: Option<RawTxResponse>;
+  wasmEnabled: boolean;
+}
+
+export const getTxDecoderQueryKey = ({
+  defer,
+  evmEnabled,
+  evmJsonRpc,
+  rawTxResponse,
+  wasmEnabled,
+}: TxDecoderQueryKeyOptions) =>
+  [
+    CELATONE_QUERY_KEYS.TX_DECODER,
+    rawTxResponse?.txhash,
+    evmEnabled,
+    evmEnabled && evmJsonRpc,
+    wasmEnabled,
+    defer,
+  ] as const;

--- a/src/lib/services/types/tx.test.ts
+++ b/src/lib/services/types/tx.test.ts
@@ -1,6 +1,18 @@
 import { zTxsResponseItemFromRest } from "./tx";
 
 jest.mock("env", () => ({ CHAIN: "initia" }));
+jest.mock("lib/utils", () => ({
+  extractTxLogs: jest.requireActual("lib/utils/tx/extractTxLogs").extractTxLogs,
+  getActionMsgType: jest.requireActual("lib/utils/extractMsgType")
+    .getActionMsgType,
+  getMsgFurtherAction: jest.requireActual("lib/utils/msgFurtherAction")
+    .getMsgFurtherAction,
+  getTxBadges: jest.requireActual("lib/utils/tx/badge").getTxBadges,
+  parseTxHash: jest.requireActual("lib/utils/txHash").parseTxHash,
+  snakeToCamel: jest.requireActual("lib/utils/formatter/snakeToCamel")
+    .snakeToCamel,
+  toChecksumAddress: jest.requireActual("lib/utils/address").toChecksumAddress,
+}));
 
 describe("zTxsResponseItemFromRest", () => {
   test("parses the raw response once and reuses the derived transaction data", () => {

--- a/src/lib/services/types/tx.test.ts
+++ b/src/lib/services/types/tx.test.ts
@@ -1,0 +1,36 @@
+import { zTxsResponseItemFromRest } from "./tx";
+
+jest.mock("env", () => ({ CHAIN: "initia" }));
+
+describe("zTxsResponseItemFromRest", () => {
+  test("parses the raw response once and reuses the derived transaction data", () => {
+    const result = zTxsResponseItemFromRest.parse({
+      code: 0,
+      codespace: "",
+      data: "",
+      events: [
+        {
+          attributes: [{ key: "sender", value: "init1sender" }],
+          type: "message",
+        },
+      ],
+      gas_used: "1",
+      gas_wanted: "1",
+      height: "1",
+      info: "",
+      logs: [],
+      raw_log: "",
+      timestamp: "2026-08-06T00:00:00Z",
+      tx: null,
+      txhash: "A".repeat(64),
+    });
+
+    if (!result.rawTxResponse || !result.txResponse) {
+      throw new Error("Expected the parsed transaction responses");
+    }
+
+    expect(result.item.hash).toBe(result.rawTxResponse.txhash);
+    expect(result.item.events).toBe(result.txResponse.events);
+    expect(result.item.created).toBe(result.txResponse.timestamp);
+  });
+});

--- a/src/lib/services/types/tx.ts
+++ b/src/lib/services/types/tx.ts
@@ -26,15 +26,13 @@ import {
   zPubkeySingle,
   zUtcDate,
 } from "lib/types";
-import {
-  extractTxLogs,
-  getActionMsgType,
-  getMsgFurtherAction,
-  getTxBadges,
-  parseTxHash,
-  snakeToCamel,
-  toChecksumAddress,
-} from "lib/utils";
+import { toChecksumAddress } from "lib/utils/address";
+import { getActionMsgType } from "lib/utils/extractMsgType";
+import { snakeToCamel } from "lib/utils/formatter/snakeToCamel";
+import { getMsgFurtherAction } from "lib/utils/msgFurtherAction";
+import { getTxBadges } from "lib/utils/tx/badge";
+import { extractTxLogs } from "lib/utils/tx/extractTxLogs";
+import { parseTxHash } from "lib/utils/txHash";
 import { z } from "zod";
 
 // ----------------------------------------
@@ -217,11 +215,13 @@ const zRawTxResponse = z.preprocess(
 );
 export type RawTxResponse = z.infer<typeof zRawTxResponse>;
 
-const zTxResponse = zRawTxResponse.transform((val) => ({
+const toTxResponse = (val: RawTxResponse) => ({
   ...snakeToCamel(val),
   logs: val.logs,
   timestamp: zUtcDate.parse(val.timestamp),
-}));
+});
+
+const zTxResponse = zRawTxResponse.transform(toTxResponse);
 export type TxResponse = Omit<
   SnakeToCamelCaseNested<z.infer<typeof zRawTxResponse>>,
   "logs" | "timestamp"
@@ -237,64 +237,68 @@ export interface TxData extends TxResponse {
   signer: BechAddr20;
 }
 
-export const zTxsResponseItemFromRest = z.preprocess(
-  (args: unknown) => {
-    const val = args as TxResponse;
-    return {
-      item: val,
-      rawTxResponse: val,
-      txResponse: val,
-    };
-  },
-  z.object({
-    item: zTxResponse.transform<TransactionWithSignerPubkey>((val) => {
-      const txBody = val.tx.body;
+const toTransactionWithSignerPubkey = (
+  val: TxResponse
+): TransactionWithSignerPubkey => {
+  const txBody = val.tx.body;
 
-      const logs = extractTxLogs(val);
+  const logs = extractTxLogs(val);
 
-      const messages = txBody.messages.map<Message>((msg, idx) => ({
-        detail: {
-          ...msg,
-        },
-        log: logs[idx],
-        type: msg["@type"] ?? msg["type"],
-      }));
+  const messages = txBody.messages.map<Message>((msg, idx) => ({
+    detail: {
+      ...msg,
+    },
+    log: logs[idx],
+    type: msg["@type"] ?? msg["type"],
+  }));
 
-      const { isEvm, isIbc, isOpinit } = messages.reduce(
-        (acc, msg, idx) => {
-          const current = getTxBadges(msg.type, logs[idx]);
-          return {
-            isEvm: acc.isEvm || current.isEvm,
-            isIbc: acc.isIbc || current.isIbc,
-            isOpinit: acc.isOpinit || current.isOpinit,
-          };
-        },
-        { isEvm: false, isIbc: false, isOpinit: false }
-      );
-
+  const { isEvm, isIbc, isOpinit } = messages.reduce(
+    (acc, msg, idx) => {
+      const current = getTxBadges(msg.type, logs[idx]);
       return {
-        // TODO: implement below later
-        actionMsgType: ActionMsgType.OTHER_ACTION_MSG,
-        created: val.timestamp,
-        events: val.events,
-        furtherAction: MsgFurtherAction.NONE,
-        hash: val.txhash,
-        height: Number(val.height),
-        isEvm,
-        isIbc,
-        isInstantiate: false,
-        isOpinit,
-        isSigner: true,
-        messages,
-        signerPubkey: val.tx.authInfo.signerInfos[0].publicKey,
-        success: val.code === 0,
+        isEvm: acc.isEvm || current.isEvm,
+        isIbc: acc.isIbc || current.isIbc,
+        isOpinit: acc.isOpinit || current.isOpinit,
       };
-    }),
-    rawTxResponse: zRawTxResponse.optional(),
-    txResponse: zTxResponse.optional(),
-  })
-);
-export type TxsResponseItemFromRest = z.infer<typeof zTxsResponseItemFromRest>;
+    },
+    { isEvm: false, isIbc: false, isOpinit: false }
+  );
+
+  return {
+    // TODO: implement below later
+    actionMsgType: ActionMsgType.OTHER_ACTION_MSG,
+    created: val.timestamp,
+    events: val.events,
+    furtherAction: MsgFurtherAction.NONE,
+    hash: val.txhash,
+    height: Number(val.height),
+    isEvm,
+    isIbc,
+    isInstantiate: false,
+    isOpinit,
+    isSigner: true,
+    messages,
+    signerPubkey: val.tx.authInfo.signerInfos[0].publicKey,
+    success: val.code === 0,
+  };
+};
+
+export interface TxsResponseItemFromRest {
+  item: TransactionWithSignerPubkey;
+  rawTxResponse?: RawTxResponse;
+  txResponse?: TxResponse;
+}
+
+export const zTxsResponseItemFromRest =
+  zRawTxResponse.transform<TxsResponseItemFromRest>((val) => {
+    const txResponse = toTxResponse(val);
+
+    return {
+      item: toTransactionWithSignerPubkey(txResponse),
+      rawTxResponse: val,
+      txResponse,
+    };
+  });
 
 export const zTxsByAddressResponseRest = z
   .object({

--- a/src/lib/services/types/tx.ts
+++ b/src/lib/services/types/tx.ts
@@ -26,13 +26,15 @@ import {
   zPubkeySingle,
   zUtcDate,
 } from "lib/types";
-import { toChecksumAddress } from "lib/utils/address";
-import { getActionMsgType } from "lib/utils/extractMsgType";
-import { snakeToCamel } from "lib/utils/formatter/snakeToCamel";
-import { getMsgFurtherAction } from "lib/utils/msgFurtherAction";
-import { getTxBadges } from "lib/utils/tx/badge";
-import { extractTxLogs } from "lib/utils/tx/extractTxLogs";
-import { parseTxHash } from "lib/utils/txHash";
+import {
+  extractTxLogs,
+  getActionMsgType,
+  getMsgFurtherAction,
+  getTxBadges,
+  parseTxHash,
+  snakeToCamel,
+  toChecksumAddress,
+} from "lib/utils";
 import { z } from "zod";
 
 // ----------------------------------------


### PR DESCRIPTION
## Summary
- Defer transaction decoding until rows/cards enter the viewport and the browser is idle
- Memoize transaction rows and mobile cards to reduce rerenders
- Use lightweight decoder query keys and reuse parsed transaction data
- Add unit tests for query keys and transaction response parsing

## Testing
- Unit tests added for transaction decoder query keys and response parsing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved transaction table performance by decoding transaction details only when rows or mobile cards become visible.
  * Reduced unnecessary re-rendering and improved layout stability while scrolling through transactions.
  * Deferred background transaction processing to help keep the interface responsive.

* **Reliability**
  * Improved transaction response parsing and normalization across supported transaction data.
  * Ensured transaction details remain consistently available after decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path list rendering and tx decode scheduling; behavior shifts from decode-all-on-mount to viewport-gated decode, which is intentional but affects how quickly message columns populate while scrolling.
> 
> **Overview**
> Fixes the transaction list freezing when users load more transactions by **deferring heavy decode work** until rows/cards are actually visible.
> 
> **`useTxDecoder`** now accepts `defer` and `enabled` options: decoding runs only when a row is in view (`react-intersection-observer`) and can wait for `requestIdleCallback` before running. React Query keys use **`txhash` via `getTxDecoderQueryKey`** instead of the full raw response, avoiding expensive hashing on large payloads. **`staleTime: Infinity`** keeps decoded results cached.
> 
> Desktop **`TransactionsTableRow`** and mobile **`TransactionsTableMobileCard`** are **`memo`**ized, wrapped with **`contentVisibility`** / intrinsic size hints for smoother scrolling, and only trigger decode when `inView`.
> 
> REST parsing in **`zTxsResponseItemFromRest`** is refactored so **`toTxResponse`** and **`toTransactionWithSignerPubkey`** run once per item instead of duplicate transforms. Unit tests cover query keys and parsing reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00fbad0792d0947d85d20a0482eb1f91e6714c96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->