### PR TITLE
fix: upgrade Vercel builds to Node.js 24 and bundle ky dependents

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -16,6 +16,10 @@ jobs:
         with:
           version: 9.10.0
           run_install: false
+      - uses: actions/setup-node@v4
+        name: Install Node.js (from engines.node)
+        with:
+          node-version-file: package.json
       - name: Run Tests
         run: |
           pnpm i

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -6,6 +6,9 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   Jest:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
+- Upgrade Vercel builds to Node.js 24: pin via `engines` and bundle `ky` dependents to fix a Node 24 `require(esm)` race during page data collection (EXP-1195)
 - Upgrade `@initia/tx-decoder` to 0.14.0 to support pretty display for `swap_and_action_with_recover` transactions (EXP-1051)
 
 ### Bug fixes

--- a/next.config.js
+++ b/next.config.js
@@ -103,6 +103,11 @@ const nextConfig = {
       },
     ];
   },
+  // Bundle CJS packages that require() the ESM-only `ky`: require(esm) (default
+  // since Node 22.12/20.19) throws ERR_REQUIRE_ESM_RACE_CONDITION/ERR_INTERNAL_ASSERTION
+  // when an import() of the same module is in flight, which Next page data
+  // collection triggers on Node 24. Bundling them avoids runtime require() entirely.
+  transpilePackages: ["@initia/utils", "@initia/interwovenkit-react", "ky"],
   webpack: (config, { webpack }) => {
     config.plugins.push(
       new webpack.DefinePlugin({

--- a/package.json
+++ b/package.json
@@ -206,6 +206,9 @@
     "typescript": "5.3.3",
     "typescript-eslint": "^8.28.0"
   },
+  "engines": {
+    "node": "24.x"
+  },
   "packageManager": "pnpm@9.10.0",
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
## Summary
- Pin `engines.node` to `24.x` so all celatone Vercel projects build on Node 24 (overrides the Node 20 project setting, which stops working after Oct 1)
- Add `transpilePackages` for `@initia/utils`, `@initia/interwovenkit-react`, `ky`: these CJS packages `require()` the ESM-only `ky`, which hits Node's `ERR_REQUIRE_ESM_RACE_CONDITION` during page data collection on Node 24
- Verified: full `next build` on Node 24 for both osmosis and initia configs, plus a browser smoke test of list/detail pages, Move `MsgExecute` arg decoding, and wallet connect

Fixes EXP-1195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the application build environment to use Node.js 24.
  * Improved build reliability and page-data generation on Vercel deployments.
  * Enhanced compatibility for key application packages during production builds.
  * Standardized automated testing on the project’s required Node.js version.

* **Documentation**
  * Added an unreleased changelog entry describing the build environment and compatibility updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production Next bundling and the Node version used for Vercel builds. A mismatch in transpile targets or engine pin could break deploys or CI, but app logic is unchanged.
> 
> **Overview**
> Pins the runtime to **Node.js 24** via `engines.node` so Vercel (and CI) pick 24 instead of the Node 20 project default.
> 
> Adds Next `transpilePackages` for `@initia/utils`, `@initia/interwovenkit-react`, and `ky` so CJS `require()` of ESM-only `ky` is bundled away. That avoids Node 24 `ERR_REQUIRE_ESM_RACE_CONDITION` during page data collection.
> 
> Jest CI now installs Node from `package.json` engines and sets `contents: read` permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbcaa835f76633e5e098ddec05867fda4f3db754. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->